### PR TITLE
Preprocessor updates to surface reflectance

### DIFF
--- a/pre_processing/cox_munk.F90
+++ b/pre_processing/cox_munk.F90
@@ -446,10 +446,6 @@ subroutine cox_munk(bands, solza, satza, solaz, totbsc, totabs, relaz, u10, v10,
 
    rsolaz = 0.
 
-   ! Note that the relative azimuth used in Cox and Munk is the other way round
-   ! from the convention used in the rest of ORAC. Here backscattering equates
-   ! to a zero relative azimuth (i.e. if the satellite is looking away from the
-   ! sun, azi = 0). Hence the 180 degree correction.
    rrelaz = d2r * relaz ! relative azimuth
 
    ! Convert wind direction to be relative to solar azimuth
@@ -835,10 +831,6 @@ subroutine cox_munk2(i_band, solza, satza, solaz, relaz, totbsc, totabs, u10, v1
 
    rsolaz = 0.
 
-   ! Note that the relative azimuth used in Cox and Munk is the other way round
-   ! from the convention used in the rest of ORAC. Here backscattering equates
-   ! to a zero relative azimuth (i.e. if the satellite is looking away from the
-   ! sun, azi = 0). Hence the 180 degree correction.
    rrelaz = d2r * relaz ! relative azimuth
 
    ! Convert wind direction to be relative to solar azimuth

--- a/pre_processing/cox_munk.F90
+++ b/pre_processing/cox_munk.F90
@@ -450,7 +450,7 @@ subroutine cox_munk(bands, solza, satza, solaz, totbsc, totabs, relaz, u10, v10,
    ! from the convention used in the rest of ORAC. Here backscattering equates
    ! to a zero relative azimuth (i.e. if the satellite is looking away from the
    ! sun, azi = 0). Hence the 180 degree correction.
-   rrelaz = d2r * (180. - relaz) ! relative azimuth
+   rrelaz = d2r * relaz ! relative azimuth
 
    ! Convert wind direction to be relative to solar azimuth
    wd(:) = rsolaz(:) - wd(:)
@@ -839,7 +839,7 @@ subroutine cox_munk2(i_band, solza, satza, solaz, relaz, totbsc, totabs, u10, v1
    ! from the convention used in the rest of ORAC. Here backscattering equates
    ! to a zero relative azimuth (i.e. if the satellite is looking away from the
    ! sun, azi = 0). Hence the 180 degree correction.
-   rrelaz = d2r * (180. - relaz) ! relative azimuth
+   rrelaz = d2r * relaz ! relative azimuth
 
    ! Convert wind direction to be relative to solar azimuth
    wd = rsolaz - wd
@@ -1088,7 +1088,7 @@ subroutine cox_munk3_calc_shared_geo_wind(solza, satza, solaz, relaz, u10, v10, 
    ! When sun and satellite are on opposite sides of pixel RAA = 0
    ! When sun and satellite are on same side of pixel RAA = 180
    ! This is the opposite notation to the rest of ORAC! So we adjust here
-   crelaz = 180. - relaz
+   crelaz = relaz
 
    !----------------------------------------------------------------------------
    ! Precalculate trigonometric functions
@@ -1485,9 +1485,9 @@ subroutine cox_munk4_calc_shared_band_geo(i_band, solza, satza, solaz, relaz, &
 #else
    shared%sin_satza = sqrt(1. - shared%cos_satza * shared%cos_satza)
 #endif
-   shared%cos_relaz = cos((180. - relaz) * d2r)
+   shared%cos_relaz = cos(relaz * d2r)
 #ifdef COMPATIBILITY_MODE
-   shared%sin_relaz = sin((180. - relaz) * d2r)
+   shared%sin_relaz = sin(relaz * d2r)
 #else
    shared%sin_relaz = sqrt(1. - shared%cos_relaz * shared%cos_relaz)
 #endif

--- a/pre_processing/get_surface_reflectance.F90
+++ b/pre_processing/get_surface_reflectance.F90
@@ -248,9 +248,9 @@ subroutine get_surface_reflectance(cyear, cdoy, cmonth, modis_surf_path, &
    ! main processor won't use them anyway.  The code below should be uncommented
    ! for option 2. Otherwise, the case of solzen > maxsza_twi is checked at the
    ! BRDF code level.
-!  do k = 1, imager_angles%nviews
-!     mask = mask .and. imager_angles%solzen(:,:,k) .lt. maxsza_twi
-!  end do
+   do k = 1, imager_angles%nviews
+      mask = mask .and. imager_angles%solzen(:,:,k) .lt. maxsza_twi
+   end do
 
    ! Count the number of land and sea pixels, using the imager land/sea mask
    nsea  = count(mask .and. imager_flags%lsflag .eq. 0)


### PR DESCRIPTION
This PR does two things:
1) Prevent calculation of surface reflectance + BRDF data for night-time pixels. This data is unnecessary (as it's night, there's no solar reflectance) and just takes up processing time.
2) Remove a hack in the cox_munk code that was used to flip the relative azimuth angles. Now that we're fixing the RAA in the satellite readers we no longer need this flip.