### PR TITLE
Reconcile remaining angles

### DIFF
--- a/pre_processing/cox_munk.F90
+++ b/pre_processing/cox_munk.F90
@@ -233,7 +233,7 @@ contains
 ! Bugs:
 ! None known.
 !-------------------------------------------------------------------------------
-subroutine cox_munk(bands, solza, satza, solaz, totbsc, totabs, relaz, u10, v10, rho)
+subroutine cox_munk(bands, solza, satza, solaz, relaz, totbsc, totabs, u10, v10, rho)
 
    use preproc_constants_m
 
@@ -1063,9 +1063,6 @@ subroutine cox_munk3_calc_shared_geo_wind(solza, satza, solaz, relaz, u10, v10, 
    ! Wind speed and direction
    real(kind=sreal) :: ws, wd
 
-   ! Corrected relaz
-   real(kind=sreal) :: crelaz
-
    ! Sun-glint/Cox and Munk variables
    real(kind=sreal) :: dangle
    real(kind=sreal) :: Zx, Zy
@@ -1074,13 +1071,6 @@ subroutine cox_munk3_calc_shared_geo_wind(solza, satza, solaz, relaz, u10, v10, 
    real(kind=sreal) :: sigx, sigy
    real(kind=sreal) :: zeta, eta
    real(kind=sreal) :: cosomega
-
-   ! !!!!! IMPORTANT NOTE !!!!!
-   ! Cox-Munk assumes that:
-   ! When sun and satellite are on opposite sides of pixel RAA = 0
-   ! When sun and satellite are on same side of pixel RAA = 180
-   ! This is the opposite notation to the rest of ORAC! So we adjust here
-   crelaz = relaz
 
    !----------------------------------------------------------------------------
    ! Precalculate trigonometric functions
@@ -1099,9 +1089,9 @@ subroutine cox_munk3_calc_shared_geo_wind(solza, satza, solaz, relaz, u10, v10, 
 #else
    shared%sin_satza = sqrt(1. - shared%cos_satza * shared%cos_satza)
 #endif
-   shared%cos_relaz = cos(crelaz * d2r)
+   shared%cos_relaz = cos(relaz * d2r)
 #ifdef COMPATIBILITY_MODE
-   shared%sin_relaz = sin(crelaz * d2r)
+   shared%sin_relaz = sin(relaz * d2r)
 #else
    shared%sin_relaz = sqrt(1. - shared%cos_relaz * shared%cos_relaz)
 #endif

--- a/pre_processing/cox_munk.F90
+++ b/pre_processing/cox_munk.F90
@@ -448,7 +448,7 @@ subroutine cox_munk(bands, solza, satza, solaz, relaz, totbsc, totabs, u10, v10,
    rsolza = d2r * solza
    rsatza = d2r * satza
 
-   rsolaz = 0.
+   rsolaz = d2r * solaz
 
    rrelaz = d2r * relaz ! relative azimuth
 
@@ -833,7 +833,7 @@ subroutine cox_munk2(i_band, solza, satza, solaz, relaz, totbsc, totabs, u10, v1
    rsolza = d2r * solza
    rsatza = d2r * satza
 
-   rsolaz = 0.
+   rsolaz = d2r * solaz
 
    rrelaz = d2r * relaz ! relative azimuth
 
@@ -1126,7 +1126,7 @@ subroutine cox_munk3_calc_shared_geo_wind(solza, satza, solaz, relaz, u10, v10, 
    !----------------------------------------------------------------------------
 
    ! Convert wind direction to be relative to solar azimuth
-   wd = wd - 0.
+   wd = wd - d2r * solaz
    if (wd .lt. 0.0) wd = 2.0*pi + wd
 
    ! Define surface slopes
@@ -1355,7 +1355,7 @@ end subroutine cox_munk3
 ! Local variables:
 ! Name Type Description
 !-------------------------------------------------------------------------------
-subroutine cox_munk4_calc_shared_wind(i_band, u10, v10, shared)
+subroutine cox_munk4_calc_shared_wind(i_band, solaz, u10, v10, shared)
 
    use preproc_constants_m
 
@@ -1363,7 +1363,7 @@ subroutine cox_munk4_calc_shared_wind(i_band, u10, v10, shared)
 
    ! Input arguments
    integer,                      intent(in)  :: i_band
-   real(kind=sreal),             intent(in)  :: u10, v10
+   real(kind=sreal),             intent(in)  :: solaz, u10, v10
 
    ! Output arguments
    type(cox_munk_shared_wind_t), intent(out) :: shared
@@ -1377,7 +1377,7 @@ subroutine cox_munk4_calc_shared_wind(i_band, u10, v10, shared)
    if (u10 .lt. 0.0) shared%wd = -shared%wd ! Azimuth angle on -180 - 180 degree interval
 
    ! Convert wind direction to be relative to solar azimuth
-   shared%wd = shared%wd - 0.
+   shared%wd = shared%wd - d2r * solaz
 
    if (shared%wd .lt. 0.0) shared%wd = 2.0*pi + shared%wd
 
@@ -1914,7 +1914,7 @@ subroutine cox_munk_rho_0v_0d_dv_and_dd(bands, solza, satza, solaz, relaz, &
          cycle
       end if
 
-      call cox_munk3_calc_shared_geo_wind(solza(i), satza(i), 0., relaz(i), &
+      call cox_munk3_calc_shared_geo_wind(solza(i), satza(i), solaz(i), relaz(i), &
                                           u10(i), v10(i), shared_geo_wind)
 
       do j = 1, n_bands
@@ -1953,7 +1953,7 @@ if (.true.) then
 
          do k = 1, n_quad_phi
             relaz2 = qx_phi(k) / d2r
-            call cox_munk3_calc_shared_geo_wind(solza(i), satza2, 0., relaz2, &
+            call cox_munk3_calc_shared_geo_wind(solza(i), satza2, solaz(i), relaz2, &
                                                 u10(i), v10(i), shared_geo_wind)
             do l = 1, n_bands
                ! If we have the Ocean_colour_cci data, then use it.
@@ -2019,7 +2019,7 @@ else
          end if
 
          solza2 = solza(j) * d2r
-         call cox_munk4_calc_shared_wind(bands(i), u10(j), v10(j), shared_wind)
+         call cox_munk4_calc_shared_wind(bands(i), solaz(j), u10(j), v10(j), shared_wind)
          do l = 1, n_quad_theta
             a = 0.
             do m = 1, n_quad_phi
@@ -2062,7 +2062,7 @@ if (.true.) then
          aa = 0.
          do k = 1, n_quad_phi
             relaz2 = qx_phi(k) / d2r
-            call cox_munk3_calc_shared_geo_wind(solza2, satza(i), 0., relaz2, &
+            call cox_munk3_calc_shared_geo_wind(solza2, satza(i), solaz(i), relaz2, &
                                                 u10(i), v10(i), shared_geo_wind)
             do l = 1, n_bands
                ! If we have the Ocean_colour_cci data, then use it. Otherwise ocean_colour
@@ -2119,7 +2119,7 @@ else
          end if
 
          satza2 = satza(j) * d2r
-         call cox_munk4_calc_shared_wind(bands(i), u10(j), v10(j), shared_wind)
+         call cox_munk4_calc_shared_wind(bands(i), solaz(j), u10(j), v10(j), shared_wind)
 
          ! If we have the Ocean_colour_cci data, then use it. Otherwise ocean_colour
          ! will just contain the default values for our bands.
@@ -2181,7 +2181,7 @@ end if
          end if
 
          call cox_munk4_calc_shared_wind(int(bands(i), kind=lint), &
-                                         u10(j), v10(j), shared_wind)
+                                         solaz(j), u10(j), v10(j), shared_wind)
 
          ! If we have the Ocean_colour_cci data, then use it. Otherwise ocean_colour
          ! will just contain the default values for our bands.

--- a/pre_processing/cox_munk.F90
+++ b/pre_processing/cox_munk.F90
@@ -114,6 +114,10 @@
 !      than chlorophyll concentration and cdom absorption
 ! 2017/08/09, GM: Switch from the NR routine gauleg() to the GPL compatible
 !    gauss_leg_quadx() for computing Gauss-Legendre quadrature.
+! 2020/07/16, AP: Invert the direction of Zy and the relative wd. The previous
+!    expressions oriented the y-axis with sunlight rather than point it towards
+!    the sun as ORAC would typically do. Details can be found at
+!    http://eodg.atm.ox.ac.uk/eodg/gray/2020Povey_relative-azimuth-surface.pdf
 !
 ! Bugs:
 ! As they aren't actually used by the code any more, the cox_munk() and
@@ -449,7 +453,7 @@ subroutine cox_munk(bands, solza, satza, solaz, relaz, totbsc, totabs, u10, v10,
    rrelaz = d2r * relaz ! relative azimuth
 
    ! Convert wind direction to be relative to solar azimuth
-   wd(:) = rsolaz(:) - wd(:)
+   wd(:) = wd(:) - rsolaz(:)
 
    where(wd .lt. 0.0) wd = 2.0*pi + wd
 
@@ -458,7 +462,7 @@ subroutine cox_munk(bands, solza, satza, solaz, relaz, totbsc, totabs, u10, v10,
 
    where (abs(dangle(:)) .gt. dither_more)
       Zx(:) = (-1.0*sin(rsatza(:)) * sin(rrelaz(:))) / dangle(:)
-      Zy(:) = (sin(rsolza(:)) + sin(rsatza(:)) * cos(rrelaz)) / dangle(:)
+      Zy(:) = -1.0 * (sin(rsolza(:)) + sin(rsatza(:)) * cos(rrelaz)) / dangle(:)
    else where
       Zx(:) = 0.0
       Zy(:) = 0.0
@@ -834,7 +838,7 @@ subroutine cox_munk2(i_band, solza, satza, solaz, relaz, totbsc, totabs, u10, v1
    rrelaz = d2r * relaz ! relative azimuth
 
    ! Convert wind direction to be relative to solar azimuth
-   wd = rsolaz - wd
+   wd = wd - rsolaz
 
    if (wd .lt. 0.0) wd = 2.0*pi + wd
 
@@ -843,7 +847,7 @@ subroutine cox_munk2(i_band, solza, satza, solaz, relaz, totbsc, totabs, u10, v1
 
    if (abs(dangle) .gt. dither_more) then
       Zx = (-1.0*sin(rsatza) * sin(rrelaz)) / dangle
-      Zy = (sin(rsolza) + sin(rsatza) * cos(rrelaz)) / dangle
+      Zy = -1.0 * (sin(rsolza) + sin(rsatza) * cos(rrelaz)) / dangle
    else
       Zx = 0.0
       Zy = 0.0
@@ -1122,8 +1126,7 @@ subroutine cox_munk3_calc_shared_geo_wind(solza, satza, solaz, relaz, u10, v10, 
    !----------------------------------------------------------------------------
 
    ! Convert wind direction to be relative to solar azimuth
-   wd = 0. - wd
-
+   wd = wd - 0.
    if (wd .lt. 0.0) wd = 2.0*pi + wd
 
    ! Define surface slopes
@@ -1131,7 +1134,7 @@ subroutine cox_munk3_calc_shared_geo_wind(solza, satza, solaz, relaz, u10, v10, 
 
    if (abs(dangle) .gt. dither_more) then
       Zx = (-1.0*shared%sin_satza * shared%sin_relaz) / dangle
-      Zy = (shared%sin_solza + shared%sin_satza*shared%cos_relaz) / dangle
+      Zy = -1.0 * (shared%sin_solza + shared%sin_satza*shared%cos_relaz) / dangle
    else
       Zx = 0.0
       Zy = 0.0
@@ -1374,7 +1377,7 @@ subroutine cox_munk4_calc_shared_wind(i_band, u10, v10, shared)
    if (u10 .lt. 0.0) shared%wd = -shared%wd ! Azimuth angle on -180 - 180 degree interval
 
    ! Convert wind direction to be relative to solar azimuth
-   shared%wd = 0. - shared%wd
+   shared%wd = shared%wd - 0.
 
    if (shared%wd .lt. 0.0) shared%wd = 2.0*pi + shared%wd
 
@@ -1485,7 +1488,7 @@ subroutine cox_munk4_calc_shared_band_geo(i_band, solza, satza, solaz, relaz, &
 
    if (abs(dangle) .gt. dither_more) then
       shared%Zx = (-1.0*shared%sin_satza * shared%sin_relaz) / dangle
-      shared%Zy = (shared%sin_solza + shared%sin_satza*shared%cos_relaz) / dangle
+      shared%Zy = -1.0 * (shared%sin_solza + shared%sin_satza*shared%cos_relaz) / dangle
    else
       shared%Zx = 0.0
       shared%Zy = 0.0

--- a/pre_processing/get_surface_reflectance.F90
+++ b/pre_processing/get_surface_reflectance.F90
@@ -545,7 +545,7 @@ subroutine get_surface_reflectance(cyear, cdoy, cmonth, modis_surf_path, &
 
             allocate(tmprho(n_bands,nland,4))
             call ross_thick_li_sparse_r_rho_0v_0d_dv_and_dd(n_bands, &
-                 solza, satza, solaz, relaz, wgtlnd, sreal_fill_value, &
+                 solza, satza, relaz, wgtlnd, sreal_fill_value, &
                  tmprho(:,:,1), tmprho(:,:,2), tmprho(:,:,3), tmprho(:,:,4), &
                  verbose)
 

--- a/pre_processing/read_avhrr_time_lat_lon_angles.F90
+++ b/pre_processing/read_avhrr_time_lat_lon_angles.F90
@@ -26,6 +26,7 @@
 ! 2013/09/06, AP: tidying, removed array initialisations as read routines
 !    cover it
 ! 2015/04/22, OS: bug fix in calculating relative azimuth angle
+! 2020/05/28, AP: Relative azimuth should be 180 when looking into the sun.
 !
 ! Bugs:
 ! None known.
@@ -124,10 +125,7 @@ subroutine read_avhrr_time_lat_lon_angles(path_to_geo_file, imager_geolocation, 
 
    ! make rel azi
    ! Note: Relative azimuth is defined so that if the satellite is looking
-   ! towards the sun (i.e. forward scattering), relative azimuth is zero.
-!   temp2 = 180.0-temp2
-!   imager_angles%relazi(:,:,1) = 180.0 - &
-!        acos(cos((temp-temp2)*d2r))/d2r
+   ! towards the sun (i.e. forward scattering), relative azimuth is 180.
 
    where ( temp2 .ne. sreal_fill_value .AND. temp .ne. sreal_fill_value )
 
@@ -135,20 +133,8 @@ subroutine read_avhrr_time_lat_lon_angles(path_to_geo_file, imager_geolocation, 
       imager_angles%satazi(:,:,1) = temp
 
       where ( imager_angles%relazi(:,:,1) .gt. 180. )
-         imager_angles%relazi(:,:,1) = imager_angles%relazi(:,:,1) - 180.
-      else where
-         imager_angles%relazi(:,:,1) = 180. - imager_angles%relazi(:,:,1)
+         imager_angles%relazi(:,:,1) = 360. - imager_angles%relazi(:,:,1)
       end where
-
-!      where ( temp2 .lt. 0 )
-!         temp2 = temp2 + 180
-!      else where
-!         temp2 = temp2 - 180
-!      end where
-
-!      imager_angles%relazi(:,:,1) = abs( temp - temp2 )
-!      where ( imager_angles%relazi(:,:,1) .gt. 180 ) imager_angles%relazi(:,:,1) = 360. - imager_angles%relazi(:,:,1)
-!      imager_angles%relazi(:,:,1) = abs( imager_angles%relazi(:,:,1) )
 
    end where
 

--- a/pre_processing/read_slstr_funcs.F90
+++ b/pre_processing/read_slstr_funcs.F90
@@ -32,6 +32,8 @@
 ! 2020/02/24, SP: Remove the S7/F1 correction, as new processing baseline makes
 !                 this harder to implement, but also makes it less necessary.
 !                 The S7 band now saturates at 312K rather than 305K.
+! 2020/04/14, AP: Add subsetting to the read functions.
+! 2020/16/07, AP: Relative azimuth should be 180 when looking into the sun.
 !
 ! Bugs:
 ! SLSTR colocation is poor. Aerosol retrieval unusable. Cloud retrieval suspect.
@@ -596,12 +598,6 @@ subroutine read_slstr_satsol(indir, imager_angles, interp, txnx, txny, nx, ny, &
       imager_angles%relazi(:,:,view) = 360. - imager_angles%relazi(:,:,view)
    end where
 
-   imager_angles%relazi(:,:,view) = abs(180. - imager_angles%relazi(:,:,view))
-
-   where (imager_angles%relazi(:,:,view) .lt. 0. .and. &
-          imager_angles%relazi(:,:,view) .ne. sreal_fill_value )
-      imager_angles%relazi(:,:,view) = 0. - imager_angles%relazi(:,:,view)
-   end where
 end subroutine read_slstr_satsol
 
 

--- a/pre_processing/ross_thick_li_sparse_r.F90
+++ b/pre_processing/ross_thick_li_sparse_r.F90
@@ -506,7 +506,6 @@ end subroutine
 ! n_bands integer In          Wavelength band index numbers
 ! solza   sreal   In          Array of solar zenith angles (in degrees)
 ! satza   sreal   In          Array of satellite zenith angles
-! solaz   sreal   In          Array of solar azimuth angles (from north)
 ! relaz   sreal   In          Array of relative azimuth angles (between sun and
 !                             satellite)
 ! f(3)    sreal   In          Ross-Thick_Li-Sparse_R weights
@@ -523,7 +522,7 @@ end subroutine
 ! Name Type Description
 !-------------------------------------------------------------------------------
 subroutine ross_thick_li_sparse_r_rho_0v_0d_dv_and_dd(n_bands, solza, satza, &
-   solaz, relaz, f, fill_value, rho_0v, rho_0d, rho_dv, rho_dd, verbose)
+   relaz, f, fill_value, rho_0v, rho_0d, rho_dv, rho_dd, verbose)
 
    use preproc_constants_m
    use gauss_leg_quad_m
@@ -534,7 +533,6 @@ subroutine ross_thick_li_sparse_r_rho_0v_0d_dv_and_dd(n_bands, solza, satza, &
    integer,          intent(in)    :: n_bands
    real(kind=sreal), intent(in)    :: solza(:)
    real(kind=sreal), intent(in)    :: satza(:)
-   real(kind=sreal), intent(in)    :: solaz(:)
    real(kind=sreal), intent(in)    :: relaz(:)
    real(kind=sreal), intent(in)    :: f(:, :, :)
    real(kind=sreal), intent(in)    :: fill_value

--- a/src/ReadSADLUT.F90
+++ b/src/ReadSADLUT.F90
@@ -726,6 +726,7 @@ subroutine Read_SAD_LUT(Ctrl, SAD_Chan, SAD_LUT, i_layer)
    integer                :: i        ! Array counters
    character(len=FilenameLen) :: LUT_file ! Name of LUT file
    character(len=4)           :: chan_num ! Channel number converted to a string
+   real, allocatable      :: tmp(:)   ! Array for flipping RelAzi
 
    ! For each cloud class, construct the LUT filename from the instrument name,
    ! cloud class ID, variable name and channel number. Then call the appropriate
@@ -820,5 +821,13 @@ subroutine Read_SAD_LUT(Ctrl, SAD_Chan, SAD_LUT, i_layer)
    if (Ctrl%Ind%NThermal > 0) then
       SAD_LUT%Em = SAD_LUT%Em / 100.
    end if
+
+   ! Invert Relazi axis
+   allocate(tmp(SAD_LUT%Grid%nRelazi))
+   do i = 1, SAD_LUT%Grid%nRelazi
+      tmp(i) = SAD_LUT%Grid%Relazi(SAD_LUT%Grid%nRelazi - i + 1)
+   end do
+   SAD_LUT%Grid%Relazi(1:SAD_LUT%Grid%nRelazi) = tmp
+   deallocate(tmp)
 
 end subroutine Read_SAD_LUT


### PR DESCRIPTION
This covers the last fixes I believe are necessary to have a consistent use of relative azimuth throughout ORAC. The reasoning for these changes is [discussed in this report](http://eodg.atm.ox.ac.uk/eodg/gray/2020Povey_relative-azimuth-satellites.pdf).
 - Flip the definition in AVHRR.
 - Flip the definition in SLSTR.
 - Flip the relative azimuth axis read from text-based LUTs.

I also make two angle-related changes to the Cox and Munk implementation. The reasoning for these is [covered in a second report](http://eodg.atm.ox.ac.uk/eodg/gray/2020Povey_relative-azimuth-surface.pdf).
 - Invert the definition of Zy so as to be consistent with ORAC's published coordinate system.
 - Use the solar azimuth within calculations, rather than assume it is zero.

The first of these introduces regressions, but they are consistent with rounding error in the albedo fields and only exceed rounding error in the retrieved fields for pixels that don't converge. The second change is negligible everywhere except the vicinity of sun glint, where it can be immense (+-30um in effective radius).

I'm in the process of validating these changes for the aerosol retrieval. Some input on the cloud would be appreciated.