### PR TITLE
USGS file orientation checking

### DIFF
--- a/pre_processing/get_USGS_data.F90
+++ b/pre_processing/get_USGS_data.F90
@@ -18,6 +18,7 @@
 ! 2016/05/31, GT: Added use_l1_land_mask argument, which provides the option of
 !    not replacing the existing imager_flags%lsflag with DEM values
 ! 2017/02/11, SP: Allow reading LSM, LUM, DEM from external file (ExtWork)
+! 2020/12/02, DP: Check if USGS file is upright (lat starts positive) or not
 !
 ! Bugs:
 ! None known.
@@ -46,10 +47,14 @@ subroutine get_USGS_data(path_to_USGS_file, imager_flags, imager_geolocation, &
    logical,                    intent(in)    :: use_predef_lsm
    character(len=*),           intent(in)    :: sensor
 
+   logical                          :: usgs_grid_upright
    logical                          :: USGS_file_exist
    character(len=7)                 :: USGS_file_read
    integer(kind=4)                  :: i, j
    integer(kind=sint), dimension(2) :: nearest_xy, maxcoord
+   ! DP: temporary array with flipped lat/lon for writing to disk
+   !real, allocatable :: tmparr2d(:,:)
+
    if (verbose) write(*,*) '<<<<<<<<<<<<<<< Entering get_USGS_data()'
 
    ! Check that the defined file exists and is readable
@@ -86,8 +91,16 @@ subroutine get_USGS_data(path_to_USGS_file, imager_flags, imager_geolocation, &
       end if
 
    else
+
       ! Read the data themselves
       call read_USGS_file(path_to_USGS_file, usgs, verbose)
+
+      ! check if USGS file lat starts positive or negative
+      if (usgs%lat(1) < 0) then
+          usgs_grid_upright = .false.
+      else
+          usgs_grid_upright = .true.
+      end if
 
       maxcoord = shape(usgs%dem)
 
@@ -104,7 +117,7 @@ subroutine get_USGS_data(path_to_USGS_file, imager_flags, imager_geolocation, &
             ! Do nearest neighbour collocation for each imager pixel with USGS
             ! data, applying a search window radius of +-0.25 degree lat/lon
             nearest_xy = nearest_USGS(imager_geolocation%latitude(i,j), &
-                 imager_geolocation%longitude(i,j), usgs)
+                 imager_geolocation%longitude(i,j), usgs, usgs_grid_upright)
 
             if (nearest_xy(2) .gt. maxcoord(1)) nearest_xy(2) = nearest_xy(2) - maxcoord(1)
             if (nearest_xy(1) .gt. maxcoord(2)) nearest_xy(1) = nearest_xy(1) - maxcoord(2)

--- a/pre_processing/get_USGS_data.F90
+++ b/pre_processing/get_USGS_data.F90
@@ -52,8 +52,6 @@ subroutine get_USGS_data(path_to_USGS_file, imager_flags, imager_geolocation, &
    character(len=7)                 :: USGS_file_read
    integer(kind=4)                  :: i, j
    integer(kind=sint), dimension(2) :: nearest_xy, maxcoord
-   ! DP: temporary array with flipped lat/lon for writing to disk
-   !real, allocatable :: tmparr2d(:,:)
 
    if (verbose) write(*,*) '<<<<<<<<<<<<<<< Entering get_USGS_data()'
 

--- a/pre_processing/read_USGS_file.F90
+++ b/pre_processing/read_USGS_file.F90
@@ -15,12 +15,14 @@
 ! 2014/09/23, OS: writes code to read data from USGS file.
 ! 2015/07/03, OS: added error status variable to nc_open call
 ! 2017/02/10, SP: Allow reading LSM, LUM, DEM from external file (ExtWork)
+! 2020/12/02, DP: Allow USGS grid to be upright (lat starts positive) or
+!                 upside down.
 !
 ! Bugs:
 ! None known.
 !-------------------------------------------------------------------------------
 
-#define ASSUME_USGS_GRID
+!#define ASSUME_USGS_GRID
 
 module USGS_physiography_m
 
@@ -176,7 +178,7 @@ subroutine read_predef_file_sev(path_to_file, usgs, verbose)
 end subroutine read_predef_file_sev
 
 !-----------------------------------------------------------------------------
-function nearest_USGS(imager_lat, imager_lon, usgs) &
+function nearest_USGS(imager_lat, imager_lon, usgs, usgs_grid_upright) &
      result(nearest_xy)
 
    implicit none
@@ -184,13 +186,20 @@ function nearest_USGS(imager_lat, imager_lon, usgs) &
    ! input variables
    real(kind=sreal),     intent(in) :: imager_lat, imager_lon
    type(USGS_t),         intent(in) :: usgs
+   logical,               intent(in) :: usgs_grid_upright
 
    ! output variable
    integer(kind=sint), dimension(2) :: nearest_xy
 
 #ifdef ASSUME_USGS_GRID
-   ! The USGS grid starts at (-179.975, 89.975)
-   nearest_xy(1) = floor((90. - imager_lat) / 180. * real(usgs%nlat)) + 1
+   if (usgs_grid_upright) then
+      ! The USGS grid starts at (-179.975, 89.975)
+      nearest_xy(1) = floor((90. - imager_lat) / 180. * real(usgs%nlat)) + 1
+   else
+      ! The USGS grid starts at (-179.975, -89.975)
+      nearest_xy(1) = (usgs%nlat - floor((90 - imager_lat) / 180. * real(usgs%nlat))) + 1
+   end if
+
    nearest_xy(2) = floor((imager_lon + 180.) / 360. * real(usgs%nlon)) + 1
 
 #else

--- a/pre_processing/read_USGS_file.F90
+++ b/pre_processing/read_USGS_file.F90
@@ -22,7 +22,7 @@
 ! None known.
 !-------------------------------------------------------------------------------
 
-!#define ASSUME_USGS_GRID
+#define ASSUME_USGS_GRID
 
 module USGS_physiography_m
 


### PR DESCRIPTION
As previously discussed, I had issues with the orientation (lat flipped) of the USGS input file containing LSM, DEM, LUS. To solve this I implemented a fix checking whether the USGS input file is upright (lat starts positive) or flipped (lat starts negative) before calculating the nearest neighbour index. 