### PR TITLE
Added external SEVIRI CPH/CMA ANN interface

### DIFF
--- a/pre_processing/Makefile
+++ b/pre_processing/Makefile
@@ -69,8 +69,8 @@ PREPROC_OBJ_F90 = $(OBJS)/aatsr_corrections.o \
                   $(OBJS)/preproc_structures.o \
                   $(OBJS)/gauss_leg_quad.o \
                   $(OBJS)/read_aatsr.o \
-				  $(OBJS)/read_abi.o \
-				  $(OBJS)/read_agri.o \
+		  $(OBJS)/read_abi.o \
+                  $(OBJS)/read_agri.o \
                   $(OBJS)/read_avhrr.o \
                   $(OBJS)/read_camel_emissivity.o \
                   $(OBJS)/read_cimss_emissivity.o \
@@ -87,7 +87,7 @@ PREPROC_OBJ_F90 = $(OBJS)/aatsr_corrections.o \
                   $(OBJS)/rttov_driver.o \
                   $(OBJS)/rttov_driver_gfs.o \
                   $(OBJS)/setup.o \
-				  $(OBJS)/seviri_neural_net_preproc.o \
+                  $(OBJS)/seviri_neural_net_preproc.o \
                   $(OBJS)/solar_position.o \
                   $(OBJS)/surface_emissivity.o \
                   $(OBJS)/surface_reflectance.o \

--- a/pre_processing/Makefile
+++ b/pre_processing/Makefile
@@ -26,7 +26,7 @@
 # 2017/02/07, SP: Added support for NOAA GFS atmosphere data (ExtWork)
 # 2017/03/29, SP: Add ability to calculate tropospheric cloud emissivity (ExtWork)
 # 2018/02/12, SP: Added the read_goes module.
-# 2019/8/14, SP: Add Fengyun-4A support.
+# 2021/01/25, DP: Added interface to external SEVIRI ANN for CMA and CPH
 #
 # Notes:
 # It appears that -lopenjpeg needs to be included in the LIBS list since on some
@@ -40,7 +40,6 @@ include $(ORAC_LIB)
 include $(ORAC_ARCH)
 
 ORAC_COMMON = ../common
-
 
 # Define object files to be linked.
 PREPROC_OBJ_F90 = $(OBJS)/aatsr_corrections.o \
@@ -70,8 +69,8 @@ PREPROC_OBJ_F90 = $(OBJS)/aatsr_corrections.o \
                   $(OBJS)/preproc_structures.o \
                   $(OBJS)/gauss_leg_quad.o \
                   $(OBJS)/read_aatsr.o \
-                  $(OBJS)/read_abi.o \
-                  $(OBJS)/read_agri.o \
+				  $(OBJS)/read_abi.o \
+				  $(OBJS)/read_agri.o \
                   $(OBJS)/read_avhrr.o \
                   $(OBJS)/read_camel_emissivity.o \
                   $(OBJS)/read_cimss_emissivity.o \
@@ -88,6 +87,7 @@ PREPROC_OBJ_F90 = $(OBJS)/aatsr_corrections.o \
                   $(OBJS)/rttov_driver.o \
                   $(OBJS)/rttov_driver_gfs.o \
                   $(OBJS)/setup.o \
+				  $(OBJS)/seviri_neural_net_preproc.o \
                   $(OBJS)/solar_position.o \
                   $(OBJS)/surface_emissivity.o \
                   $(OBJS)/surface_reflectance.o \
@@ -133,7 +133,6 @@ depend:
 
 clean tidy:
 	rm -f $(OBJS)/*.o $(OBJS)/*.mod *.a orac_preproc
-
 
 # Fortran 90 dependencies
 include dependencies.inc

--- a/pre_processing/dependencies.inc
+++ b/pre_processing/dependencies.inc
@@ -10,6 +10,7 @@ $(OBJS)/cloud_emis.o: $(OBJS)/channel_structures.o $(OBJS)/ecmwf.o \
         $(OBJS)/preproc_structures.o
 $(OBJS)/cloud_typing_pavolonis.o: $(OBJS)/channel_structures.o $(OBJS)/ecmwf.o \
         $(OBJS)/imager_structures.o $(OBJS)/neural_net_preproc.o \
+        $(OBJS)/seviri_neural_net_preproc.o \
         $(OBJS)/surface_structures.o pavolonis_fill_coefficients.inc
 $(OBJS)/correct_for_ice_snow.o: $(OBJS)/channel_structures.o \
         $(OBJS)/imager_structures.o $(OBJS)/nsidc_nise.o \
@@ -100,6 +101,8 @@ $(OBJS)/rttov_driver.o: $(OBJS)/channel_structures.o $(OBJS)/netcdf_output.o \
 $(OBJS)/rttov_driver_gfs.o: $(OBJS)/channel_structures.o $(OBJS)/netcdf_output.o \
         $(OBJS)/preproc_constants.o $(OBJS)/preproc_structures.o \
         $(OBJS)/remove_rayleigh.o write_ir_rttov.F90 write_solar_rttov.F90
+$(OBJS)/seviri_neural_net_preproc.o: $(OBJS)/preproc_constants.o \
+        $(OBJS)/imager_structures.o
 $(OBJS)/setup.o: $(OBJS)/calender.o $(OBJS)/channel_structures.o \
         $(OBJS)/preproc_constants.o $(OBJS)/preproc_structures.o
 $(OBJS)/surface_emissivity.o: $(OBJS)/channel_structures.o \

--- a/pre_processing/orac_preproc.F90
+++ b/pre_processing/orac_preproc.F90
@@ -517,6 +517,7 @@ subroutine orac_preproc(mytask, ntasks, lower_bound, upper_bound, driver_path_fi
    preproc_opts%do_co2                    = .true.
    preproc_opts%use_swansea_climatology   = .false.
    preproc_opts%swansea_gamma             = 0.3
+   preproc_opts%use_seviri_ann            = .false.
 
    ! Initialise satellite position string
    global_atts%Satpos_Metadata = 'null'
@@ -589,7 +590,6 @@ subroutine orac_preproc(mytask, ntasks, lower_bound, upper_bound, driver_path_fi
       else if (nargs .eq. -1) then
          index_space = index(driver_path_file, " ")
          driver_path_file = driver_path_file(1:(index_space-1))
-         write(*,*) 'inside preproc: ', trim(adjustl(driver_path_file))
       end if
 
       open(11, file=trim(adjustl(driver_path_file)), status='old', &
@@ -650,6 +650,7 @@ subroutine orac_preproc(mytask, ntasks, lower_bound, upper_bound, driver_path_fi
 
       close(11)
    end if
+
    ! Set this since it was removed from the command line but not removed from
    ! the global attributes.
    global_atts%L2_Processor_Version = '1.0'
@@ -1208,12 +1209,14 @@ subroutine orac_preproc(mytask, ntasks, lower_bound, upper_bound, driver_path_fi
                call cloud_type(channel_info, sensor, surface, imager_flags, &
                     imager_angles, imager_geolocation, imager_measurements, &
                     imager_pavolonis, ecmwf, platform, doy, preproc_opts%do_ironly, &
-                    do_spectral_response_correction, verbose)
+                    do_spectral_response_correction, preproc_opts%use_seviri_ann, &
+                    verbose)
             else
                call cloud_type(channel_info, sensor, surface, imager_flags, &
                     imager_angles, imager_geolocation, imager_measurements, &
                     imager_pavolonis, ecmwf_HR, platform, doy, preproc_opts%do_ironly, &
-                    do_spectral_response_correction, verbose)
+                    do_spectral_response_correction, preproc_opts%use_seviri_ann, &
+                    verbose)
             end if
          end if
       end if

--- a/pre_processing/preproc_structures.F90
+++ b/pre_processing/preproc_structures.F90
@@ -86,6 +86,7 @@ module preproc_structures_m
       logical                    :: use_predef_geo
       logical                    :: use_predef_lsm
       logical                    :: use_swansea_climatology
+      logical                    :: use_seviri_ann
 
       character(len=path_length) :: ecmwf_path(2)
       character(len=path_length) :: ecmwf_path2(2)

--- a/pre_processing/seviri_neural_net_preproc.F90
+++ b/pre_processing/seviri_neural_net_preproc.F90
@@ -1,0 +1,90 @@
+!-------------------------------------------------------------------------------
+! Module calling the library for the external SEVIRI neural network cloud
+! detection and cloud phase determination. This module is the bridge 
+! between ORAC and the external library in external_ml/seviri.
+!
+! 2020/09/16, DP: Initial version.
+!
+! Bugs:
+! None known.
+!-------------------------------------------------------------------------------
+
+module seviri_neural_net_preproc_m
+     
+     implicit None
+
+     contains
+
+
+subroutine cma_cph_seviri(cview, imager_flags, imager_angles, imager_geolocation, &
+                          imager_measurements, imager_pavolonis, skt, channel_info)
+
+#ifdef INCLUDE_SEVIRI_NEURALNET
+     use SEVIRI_NEURAL_NET_M
+#endif
+     use preproc_constants_m
+     use imager_structures_m
+     use channel_structures_m
+
+     ! arguments
+     integer,                     intent(in)     :: cview
+     type(imager_flags_t),        intent(in)     :: imager_flags
+     type(imager_angles_t),       intent(in)     :: imager_angles
+     type(imager_geolocation_t),  intent(in)     :: imager_geolocation
+     type(imager_measurements_t), intent(in)     :: imager_measurements
+     type(imager_pavolonis_t),    intent(inout)  :: imager_pavolonis
+     type(channel_info_t),        intent(in)     :: channel_info
+     real(kind=sreal),            intent(in)     :: &
+          skt(imager_geolocation%startx:imager_geolocation%endx, &
+              1:imager_geolocation%ny)
+
+     ! channels
+     integer :: ch1, ch2, ch3, ch4, ch5, ch6, ch7, ch9, ch10, ch11
+       
+     ! channel indices     
+     ch1 = 1
+     ch2 = 2
+     ch3 = 3
+     ch4 = 4
+     ch5 = 5
+     ch6 = 6
+     ch7 = 7
+     ch9 = 9
+     ch10 = 10
+     ch11 = 11
+
+#ifdef INCLUDE_SEVIRI_NEURALNET
+     write(*,*) "PREDICTING COT/CPH"     
+     ! run external ANN
+     call seviri_ann_cph_cot(imager_geolocation%nx, &  ! xdim for reshaping
+                imager_geolocation%ny, &               ! ydim for reshaping
+                imager_measurements%data(:,:,ch1), &   ! VIS006
+                imager_measurements%data(:,:,ch2), &   ! VIS008
+                imager_measurements%data(:,:,ch3), &   ! NIR016
+                imager_measurements%data(:,:,ch4), &   ! IR039
+                imager_measurements%data(:,:,ch5), &   ! IR062
+                imager_measurements%data(:,:,ch6), &   ! IR073
+                imager_measurements%data(:,:,ch7), &   ! IR087
+                imager_measurements%data(:,:,ch9), &   ! IR108
+                imager_measurements%data(:,:,ch10), &  ! IR120
+                imager_measurements%data(:,:,ch11), &  ! IR134
+                imager_flags%lsflag, &                 ! Land-sea mask
+                skt, &                                 ! ECMWF skin temp
+                imager_pavolonis%cccot_pre(:,:,cview), &
+                imager_pavolonis%cldmask(:,:,cview), &
+                imager_pavolonis%cldmask_uncertainty(:,:,cview), &
+                imager_pavolonis%cphcot(:,:,cview), &
+                imager_pavolonis%ann_phase(:,:,cview), &
+                imager_pavolonis%ann_phase_uncertainty(:,:,cview))
+     
+#else
+     write(*,*) 'ERROR: ORAC has been compiled without SEVIRI neural ' \\ & 
+                'network support. (1) Compile the SEVIRI neural ' \\ &
+                'network in ../seviri_neuralnet. (2) Link the modules' \\ &
+                'to the ORAC pre_processor compilation. (3) Recompile ' \\ &
+                'ORAC with -DINCLUDE_SEVIRI_NEURALNET.'
+     stop error_stop_code     
+#endif
+
+end subroutine cma_cph_seviri
+end module seviri_neural_net_preproc_m

--- a/pre_processing/utils_for_main.F90
+++ b/pre_processing/utils_for_main.F90
@@ -74,7 +74,6 @@ subroutine parse_optional(label, value, preproc_opts)
    character(len=*),     intent(in)    :: value
    type(preproc_opts_t), intent(inout) :: preproc_opts
 
-
    select case (label)
    case('N_CHANNELS')
       if (parse_string(value, preproc_opts%n_channels) /= 0) &
@@ -167,6 +166,9 @@ subroutine parse_optional(label, value, preproc_opts)
            call handle_parse_error(label)
    case('SWANSEA_GAMMA')
       if (parse_string(value, preproc_opts%swansea_gamma) /= 0) &
+           call handle_parse_error(label)
+   case('USE_SEVIRI_ANN')
+      if (parse_string(value, preproc_opts%use_seviri_ann) /= 0) &
            call handle_parse_error(label)
    case default
       write(*,*) 'ERROR: Unknown option: ', trim(label)


### PR DESCRIPTION
Similar to the previous PR for the new SEVIRI ANN, only that the SEVIRI ANN has now been moved to an external repository (Temporary repo: https://github.com/danielphilipp/seviri_ml). 

The external ANN will be transferred to https://github.com/ORAC-CC/seviri_ml  as soon as possible.
