### PR TITLE
Shift SEVIRI satellite azimuth range to match ORAC definition

### DIFF
--- a/pre_processing/read_seviri.F90
+++ b/pre_processing/read_seviri.F90
@@ -262,6 +262,9 @@ subroutine read_seviri_l1_5(l1_5_file, imager_geolocation, imager_measurements, 
       end where
    end where
 
+   ! Shift satazi range from [0,360] to [-180,180] to be consistent with ORAC
+   imager_angles%satazi = imager_angles%satazi - 180.
+
    deallocate(tmparr)
 
 end subroutine read_seviri_l1_5

--- a/pre_processing/read_seviri.F90
+++ b/pre_processing/read_seviri.F90
@@ -15,6 +15,8 @@
 !                 setting is ON, meaning that GSICS coefficients will be used
 !                 instead of IMPF (as previous). The new driver file option
 !                 USE_GSICS enables this to be disabled.
+! 2021/02/23, DP: Shifted satellite azimuth from [0,360] to [-180,180] range
+!                 to match ORAC definition.
 !
 ! Bugs:
 ! None known.
@@ -226,8 +228,6 @@ subroutine read_seviri_l1_5(l1_5_file, imager_geolocation, imager_measurements, 
    type(global_attributes_t),   intent(inout) :: global_atts
    logical,                     intent(in)    :: verbose
 
-   real, allocatable :: tmparr(:,:,:)
-
    integer :: startx
 
    if (determine_seviri_file_type(l1_5_file) == SEVIRI_TYPE_METOFF) then
@@ -240,12 +240,7 @@ subroutine read_seviri_l1_5(l1_5_file, imager_geolocation, imager_measurements, 
            do_gsics, global_atts, verbose)
    end if
 
-   allocate(tmparr(1:imager_geolocation%nx,1:imager_geolocation%ny,1))
-
    startx = imager_geolocation%startx
-
-   tmparr = imager_angles%satazi(imager_geolocation%endx:imager_geolocation%startx:-1,:,:)
-   imager_angles%satazi = tmparr
 
    where(imager_angles%solazi(startx:,:,1) .ne. sreal_fill_value .and. &
          imager_angles%satazi(startx:,:,1) .ne. sreal_fill_value)
@@ -263,9 +258,9 @@ subroutine read_seviri_l1_5(l1_5_file, imager_geolocation, imager_measurements, 
    end where
 
    ! Shift satazi range from [0,360] to [-180,180] to be consistent with ORAC
-   imager_angles%satazi = imager_angles%satazi - 180.
-
-   deallocate(tmparr)
+   where (imager_angles%satazi .gt. 180)
+      imager_angles%satazi = imager_angles%satazi - 360.
+   end where
 
 end subroutine read_seviri_l1_5
 


### PR DESCRIPTION
The SEVIRI reader outputs the satellite azimuth in the range [0,360] whereas ORAC expects the satellite azimuth to be in the range [-180,180]. Thus the main processor sets pixels with satellite azimuth to fill value so that half of the SEVIRI disk is missing. 

Introduced a shift of the satellite azimuth within the reader by 180 degrees to match the ORAC definition.

New satellite azimuth outputted by the main processor looks correct:

![satazi_new](https://user-images.githubusercontent.com/51949198/108184482-9008b200-710b-11eb-8320-74252291fa45.png)

Please note that the image is east-west flipped so that the satazi increases counter-clockwise. In the correct orientation it increases clockwise.