### PR TITLE
Update ecmwf flags and enable support for ERA5 data on JASMIN

### DIFF
--- a/pre_processing/correct_for_ice_snow.F90
+++ b/pre_processing/correct_for_ice_snow.F90
@@ -585,7 +585,7 @@ end subroutine apply_ice_correction
 !-------------------------------------------------------------------------------
 !------------------------------------------------------------------------------
 
-subroutine correct_for_ice_snow_ecmwf(ecmwf_path, imager_geolocation, &
+subroutine correct_for_ice_snow_ecmwf(nwp_path, imager_geolocation, &
      channel_info, imager_flags, preproc_dims, preproc_prtm, surface, &
      include_full_brdf, source_atts, verbose)
 
@@ -600,7 +600,7 @@ subroutine correct_for_ice_snow_ecmwf(ecmwf_path, imager_geolocation, &
    implicit none
 
    ! Arguments
-   character(len=*),           intent(in)    :: ecmwf_path
+   character(len=*),           intent(in)    :: nwp_path
    type(imager_geolocation_t), intent(in)    :: imager_geolocation
    type(channel_info_t),       intent(in)    :: channel_info
    type(imager_flags_t),       intent(in)    :: imager_flags
@@ -630,8 +630,8 @@ subroutine correct_for_ice_snow_ecmwf(ecmwf_path, imager_geolocation, &
    snow_threshold = 0.01 ! I belive this is 1cm
    ice_threshold = 0.15 ! I believe this is 15%
 
-   source_atts%snow_file = trim(ecmwf_path)
-   source_atts%sea_ice_file = trim(ecmwf_path)
+   source_atts%snow_file = trim(nwp_path)
+   source_atts%sea_ice_file = trim(nwp_path)
 
    do i = 1, channel_info%nchannels_total
       if (channel_info%map_ids_abs_to_snow_and_ice(i) .le. 0) cycle

--- a/pre_processing/correct_for_ice_snow.F90
+++ b/pre_processing/correct_for_ice_snow.F90
@@ -585,7 +585,7 @@ end subroutine apply_ice_correction
 !-------------------------------------------------------------------------------
 !------------------------------------------------------------------------------
 
-subroutine correct_for_ice_snow_ecmwf(ecmwf_HR_path, imager_geolocation, &
+subroutine correct_for_ice_snow_ecmwf(ecmwf_path, imager_geolocation, &
      channel_info, imager_flags, preproc_dims, preproc_prtm, surface, &
      include_full_brdf, source_atts, verbose)
 
@@ -600,7 +600,7 @@ subroutine correct_for_ice_snow_ecmwf(ecmwf_HR_path, imager_geolocation, &
    implicit none
 
    ! Arguments
-   character(len=*),           intent(in)    :: ecmwf_HR_path
+   character(len=*),           intent(in)    :: ecmwf_path
    type(imager_geolocation_t), intent(in)    :: imager_geolocation
    type(channel_info_t),       intent(in)    :: channel_info
    type(imager_flags_t),       intent(in)    :: imager_flags
@@ -630,8 +630,8 @@ subroutine correct_for_ice_snow_ecmwf(ecmwf_HR_path, imager_geolocation, &
    snow_threshold = 0.01 ! I belive this is 1cm
    ice_threshold = 0.15 ! I believe this is 15%
 
-   source_atts%snow_file = trim(ecmwf_HR_path)
-   source_atts%sea_ice_file = trim(ecmwf_HR_path)
+   source_atts%snow_file = trim(ecmwf_path)
+   source_atts%sea_ice_file = trim(ecmwf_path)
 
    do i = 1, channel_info%nchannels_total
       if (channel_info%map_ids_abs_to_snow_and_ice(i) .le. 0) cycle

--- a/pre_processing/deallocate_ecmwf_structures.F90
+++ b/pre_processing/deallocate_ecmwf_structures.F90
@@ -23,23 +23,20 @@
 ! None known.
 !-------------------------------------------------------------------------------
 
-subroutine deallocate_ecmwf_structures(ecmwf, low_res)
+subroutine deallocate_ecmwf_structures(ecmwf)
 
    use preproc_constants_m
 
    implicit none
 
    type(ecmwf_t), intent(inout) :: ecmwf
-   logical,       intent(in)    :: low_res
 
    deallocate(ecmwf%lon)
    deallocate(ecmwf%lat)
-   if (low_res) then
-      deallocate(ecmwf%avec)
-      deallocate(ecmwf%bvec)
-      deallocate(ecmwf%u10)
-      deallocate(ecmwf%v10)
-   end if
+   deallocate(ecmwf%avec)
+   deallocate(ecmwf%bvec)
+   deallocate(ecmwf%u10)
+   deallocate(ecmwf%v10)
    deallocate(ecmwf%skin_temp)
    deallocate(ecmwf%snow_depth)
    deallocate(ecmwf%sea_ice_cover)

--- a/pre_processing/dependencies.inc
+++ b/pre_processing/dependencies.inc
@@ -22,7 +22,7 @@ $(OBJS)/define_preprop_grid.o: $(OBJS)/imager_structures.o \
         $(OBJS)/preproc_constants.o $(OBJS)/preproc_structures.o
 $(OBJS)/ecmwf.o: $(OBJS)/preproc_constants.o $(OBJS)/preproc_structures.o \
         compute_geopot_coordinate.F90 deallocate_ecmwf_structures.F90 \
-        read_ecmwf.F90 read_ecmwf_grib.F90 read_ecmwf_nc.F90 \
+        read_ecmwf.F90 read_era5_jasmin.F90 read_ecmwf_grib.F90 read_ecmwf_nc.F90 \
         read_ecmwf_wind_badc.F90 read_ecmwf_wind_grib.F90 read_ecmwf_wind_nc.F90 \
         read_gfs_grib.F90 read_gfs_nc.F90 rearrange_ecmwf.F90
 $(OBJS)/fill_grid.o: $(OBJS)/preproc_constants.o

--- a/pre_processing/ecmwf.F90
+++ b/pre_processing/ecmwf.F90
@@ -300,13 +300,12 @@ subroutine ecmwf_wind_init(ecmwf)
 end subroutine ecmwf_wind_init
 
 
-subroutine dup_ecmwf_allocation(ecmwf, ecmwf2, low_res)
+subroutine dup_ecmwf_allocation(ecmwf, ecmwf2)
 
    implicit none
 
    type(ecmwf_t), intent(in)  :: ecmwf
    type(ecmwf_t), intent(inout) :: ecmwf2
-   logical,       intent(in)  :: low_res
 
    ecmwf2%xdim = ecmwf%xdim
    ecmwf2%ydim = ecmwf%ydim
@@ -314,12 +313,10 @@ subroutine dup_ecmwf_allocation(ecmwf, ecmwf2, low_res)
 
    allocate(ecmwf2%lon(ecmwf%xdim))
    allocate(ecmwf2%lat(ecmwf%ydim))
-   if (low_res) then
-      allocate(ecmwf2%avec(ecmwf%kdim+1))
-      allocate(ecmwf2%bvec(ecmwf%kdim+1))
-      allocate(ecmwf2%u10(ecmwf%xdim,ecmwf%ydim))
-      allocate(ecmwf2%v10(ecmwf%xdim,ecmwf%ydim))
-   end if
+   allocate(ecmwf2%avec(ecmwf%kdim+1))
+   allocate(ecmwf2%bvec(ecmwf%kdim+1))
+   allocate(ecmwf2%u10(ecmwf%xdim,ecmwf%ydim))
+   allocate(ecmwf2%v10(ecmwf%xdim,ecmwf%ydim))
    allocate(ecmwf2%skin_temp(ecmwf%xdim,ecmwf%ydim))
    allocate(ecmwf2%snow_depth(ecmwf%xdim,ecmwf%ydim))
    allocate(ecmwf2%sea_ice_cover(ecmwf%xdim,ecmwf%ydim))
@@ -327,7 +324,7 @@ subroutine dup_ecmwf_allocation(ecmwf, ecmwf2, low_res)
 end subroutine dup_ecmwf_allocation
 
 
-subroutine linearly_combine_ecmwfs(a, b, ecmwf1, ecmwf2, ecmwf, low_res)
+subroutine linearly_combine_ecmwfs(a, b, ecmwf1, ecmwf2, ecmwf)
 
    implicit none
 
@@ -336,16 +333,15 @@ subroutine linearly_combine_ecmwfs(a, b, ecmwf1, ecmwf2, ecmwf, low_res)
    type(ecmwf_t), intent(in)  :: ecmwf1
    type(ecmwf_t), intent(in)  :: ecmwf2
    type(ecmwf_t), intent(inout) :: ecmwf
-   logical,       intent(in)  :: low_res
 
-   ecmwf%lat               = a * ecmwf1%lat        + b * ecmwf2%lat
-   ecmwf%lon               = a * ecmwf1%lon        + b * ecmwf2%lon
-   if (low_res) ecmwf%avec = a * ecmwf1%avec       + b * ecmwf2%avec
-   if (low_res) ecmwf%bvec = a * ecmwf1%bvec       + b * ecmwf2%bvec
-   if (low_res) ecmwf%u10  = a * ecmwf1%u10        + b * ecmwf2%u10
-   if (low_res) ecmwf%v10  = a * ecmwf1%v10        + b * ecmwf2%v10
-   ecmwf%skin_temp         = a * ecmwf1%skin_temp  + b * ecmwf2%skin_temp
-   ecmwf%snow_depth        = a * ecmwf1%snow_depth + b * ecmwf2%snow_depth
+   ecmwf%lat  = a * ecmwf1%lat        + b * ecmwf2%lat
+   ecmwf%lon  = a * ecmwf1%lon        + b * ecmwf2%lon
+   ecmwf%avec = a * ecmwf1%avec       + b * ecmwf2%avec
+   ecmwf%bvec = a * ecmwf1%bvec       + b * ecmwf2%bvec
+   ecmwf%u10  = a * ecmwf1%u10        + b * ecmwf2%u10
+   ecmwf%v10  = a * ecmwf1%v10        + b * ecmwf2%v10
+   ecmwf%skin_temp = a * ecmwf1%skin_temp  + b * ecmwf2%skin_temp
+   ecmwf%snow_depth = a * ecmwf1%snow_depth + b * ecmwf2%snow_depth
 
    ecmwf%sea_ice_cover = sreal_fill_value
    where (ecmwf1%sea_ice_cover .ne. sreal_fill_value .and. &

--- a/pre_processing/ecmwf.F90
+++ b/pre_processing/ecmwf.F90
@@ -52,6 +52,7 @@ contains
 #include "deallocate_ecmwf_structures.F90"
 #include "compute_geopot_coordinate.F90"
 #include "read_ecmwf.F90"
+#include "read_era5_jasmin.F90"
 #include "read_ecmwf_wind_nc.F90"
 #include "read_ecmwf_wind_grib.F90"
 #include "read_ecmwf_wind_badc.F90"

--- a/pre_processing/netcdf_output_create.F90
+++ b/pre_processing/netcdf_output_create.F90
@@ -22,7 +22,7 @@
 ! netcdf_info    struct  both Summary of NCDF file properties.
 ! channel_info   struct  in   Structure summarising the channels to be processed
 ! include_full_brdf logic in  T: Use BRDF surface; F: Use Lambertian surface.
-! ecmwf_flag     logic   in   See set_ecmwf.F90
+! nwp_flag     logic   in   See set_ecmwf.F90
 ! do_cloud_emis  logic   in   T: Output cloud emissivity; F: Don't.
 ! use_chunking   logic   in   T: Chunk output file; F: Don't.
 !
@@ -54,7 +54,7 @@
 
 subroutine netcdf_output_create(output_path, paths, granule, global_atts, &
    source_atts, preproc_dims, imager_angles, imager_geolocation, netcdf_info, &
-   channel_info, include_full_brdf, ecmwf_flag, do_cloud_emis, verbose)
+   channel_info, include_full_brdf, nwp_flag, do_cloud_emis, verbose)
 
    use channel_structures_m
    use global_attributes_m
@@ -80,7 +80,7 @@ subroutine netcdf_output_create(output_path, paths, granule, global_atts, &
 
    type(channel_info_t),       intent(in)    :: channel_info
    logical,                    intent(in)    :: include_full_brdf
-   integer,                    intent(in)    :: ecmwf_flag
+   integer,                    intent(in)    :: nwp_flag
    logical,                    intent(in)    :: do_cloud_emis
    logical,                    intent(in)    :: verbose
 
@@ -101,7 +101,7 @@ subroutine netcdf_output_create(output_path, paths, granule, global_atts, &
         granule%cminute, granule%platform, granule%sensor, &
         trim(adjustl(output_path))//'/'//trim(adjustl(paths%prtm_file)), &
         NETCDF_OUTPUT_FILE_PRTM, preproc_dims, netcdf_info, channel_info, &
-        ecmwf_flag, verbose)
+        nwp_flag, verbose)
 
    ! create lwrtm file
    call netcdf_create_rtm(global_atts, source_atts, granule%cyear, &
@@ -109,7 +109,7 @@ subroutine netcdf_output_create(output_path, paths, granule, global_atts, &
         granule%cminute, granule%platform, granule%sensor, &
         trim(adjustl(output_path))//'/'//trim(adjustl(paths%lwrtm_file)), &
         NETCDF_OUTPUT_FILE_LWRTM, preproc_dims, netcdf_info, channel_info, &
-        ecmwf_flag, verbose)
+        nwp_flag, verbose)
 
    ! create swrtm file
    call netcdf_create_rtm(global_atts, source_atts, granule%cyear, &
@@ -117,7 +117,7 @@ subroutine netcdf_output_create(output_path, paths, granule, global_atts, &
         granule%cminute, granule%platform, granule%sensor, &
         trim(adjustl(output_path))//'/'//trim(adjustl(paths%swrtm_file)), &
         NETCDF_OUTPUT_FILE_SWRTM, preproc_dims, netcdf_info, channel_info, &
-        ecmwf_flag, verbose)
+        nwp_flag, verbose)
 
 
    ! Create swath based files

--- a/pre_processing/netcdf_output_create_file.F90
+++ b/pre_processing/netcdf_output_create_file.F90
@@ -93,7 +93,7 @@
 ! 2015/07/23, GM: Added specific humidity and ozone PRTM fields.
 ! 2016/03/31, GM: Changes to support processing only SW or only LW channels.
 ! 2017/02/07, SP: Added support for NOAA GFS atmosphere data (ExtWork)
-! 2017/04/11, SP: Added ecmwf_flag=6, for working with GFS analysis files.
+! 2017/04/11, SP: Added nwp_flag=6, for working with GFS analysis files.
 ! 2017/06/21, OS: Added ANN phase variables
 ! 2018/04/26, SP: Add code to save satellite azimuth
 ! 2018/04/29, SP: Add cloud emissivity support for ECMWF profiles (ExtWork)
@@ -106,7 +106,7 @@
 
 subroutine netcdf_create_rtm(global_atts, source_atts, cyear, cmonth, cday, chour, &
      cminute, platform, sensor, path, type, preproc_dims, netcdf_info, channel_info, &
-     ecmwf_flag, verbose)
+     nwp_flag, verbose)
 
    use netcdf
 
@@ -135,7 +135,7 @@ subroutine netcdf_create_rtm(global_atts, source_atts, cyear, cmonth, cday, chou
    type(preproc_dims_t),       intent(in)    :: preproc_dims
    type(netcdf_output_info_t), intent(inout) :: netcdf_info
    type(channel_info_t),       intent(in)    :: channel_info
-   integer,                    intent(in)    :: ecmwf_flag
+   integer,                    intent(in)    :: nwp_flag
    logical,                    intent(in)    :: verbose
 
    ! Local
@@ -154,9 +154,9 @@ subroutine netcdf_create_rtm(global_atts, source_atts, cyear, cmonth, cday, chou
 
    ! Set number of vertical levels/layers here, as GFS is different to ECMWF
    kdim = preproc_dims%kdim+1
-   if (ecmwf_flag .eq. 6) kdim = kdim-1
-   if (ecmwf_flag .eq. 7) kdim = kdim-1
-   if (ecmwf_flag .eq. 8) kdim = kdim-1
+   if (nwp_flag .eq. 6) kdim = kdim-1
+   if (nwp_flag .eq. 7) kdim = kdim-1
+   if (nwp_flag .eq. 8) kdim = kdim-1
 
    if (type .eq. NETCDF_OUTPUT_FILE_LWRTM) then
 

--- a/pre_processing/netcdf_output_create_file.F90
+++ b/pre_processing/netcdf_output_create_file.F90
@@ -154,9 +154,7 @@ subroutine netcdf_create_rtm(global_atts, source_atts, cyear, cmonth, cday, chou
 
    ! Set number of vertical levels/layers here, as GFS is different to ECMWF
    kdim = preproc_dims%kdim+1
-   if (nwp_flag .eq. 6) kdim = kdim-1
-   if (nwp_flag .eq. 7) kdim = kdim-1
-   if (nwp_flag .eq. 8) kdim = kdim-1
+   if (nwp_flag .eq. 0) kdim = kdim-1
 
    if (type .eq. NETCDF_OUTPUT_FILE_LWRTM) then
 

--- a/pre_processing/orac_preproc.F90
+++ b/pre_processing/orac_preproc.F90
@@ -460,10 +460,10 @@ subroutine orac_preproc(mytask, ntasks, lower_bound, upper_bound, driver_path_fi
    preproc_opts%ecmwf_time_int_method     = 2
    preproc_opts%use_ecmwf_snow_and_ice    = .true.
    preproc_opts%use_modis_emis_in_rttov   = .false.
-   preproc_nwp_fnames%nwp_path(2)             = ' '
-   preproc_nwp_fnames%nwp_path2(2)            = ' '
-   preproc_nwp_fnames%nwp_path3(2)            = ' '
-   preproc_opts%nwp_nlevels             = 0
+   preproc_nwp_fnames%nwp_path(2)         = ' '
+   preproc_nwp_fnames%nwp_path2(2)        = ' '
+   preproc_nwp_fnames%nwp_path3(2)        = ' '
+   preproc_opts%nwp_nlevels               = 0
    preproc_opts%nwp_time_factor           = 6.
    preproc_opts%use_l1_land_mask          = .false.
    preproc_opts%use_occci                 = .false.

--- a/pre_processing/orac_preproc.F90
+++ b/pre_processing/orac_preproc.F90
@@ -846,10 +846,10 @@ subroutine orac_preproc(mytask, ntasks, lower_bound, upper_bound, driver_path_fi
 
       ! read surface wind fields and ECMWF dimensions
       if (preproc_opts%ecmwf_time_int_method .ne. 2) then
-         call read_ecmwf_wind(nwp_flag, preproc_nwp_fnames%nwp_path_file(1), preproc_nwp_fnames%nwp_path_file2(1), preproc_nwp_fnames%nwp_path_file3(1), ecmwf, preproc_opts%nwp_nlevels, verbose)
+         call read_ecmwf_wind(nwp_flag, preproc_nwp_fnames, 1, ecmwf, preproc_opts%nwp_nlevels, verbose)
       else
-         call read_ecmwf_wind(nwp_flag, preproc_nwp_fnames%nwp_path_file(1), preproc_nwp_fnames%nwp_path_file2(1), preproc_nwp_fnames%nwp_path_file3(1), ecmwf1, preproc_opts%nwp_nlevels, verbose)
-         call read_ecmwf_wind(nwp_flag, preproc_nwp_fnames%nwp_path_file(2), preproc_nwp_fnames%nwp_path_file2(2), preproc_nwp_fnames%nwp_path_file3(2), ecmwf2, preproc_opts%nwp_nlevels, verbose)
+         call read_ecmwf_wind(nwp_flag, preproc_nwp_fnames, 1, ecmwf1, preproc_opts%nwp_nlevels, verbose)
+         call read_ecmwf_wind(nwp_flag, preproc_nwp_fnames, 2, ecmwf2, preproc_opts%nwp_nlevels, verbose)
 
          call dup_ecmwf_allocation(ecmwf1, ecmwf)
 
@@ -879,18 +879,15 @@ subroutine orac_preproc(mytask, ntasks, lower_bound, upper_bound, driver_path_fi
       ! read ecmwf era interim file
       if (verbose) write(*,*) 'Read and interpolate NWP / Reanalysis data.'
       if (preproc_opts%ecmwf_time_int_method .ne. 2) then
-         call read_ecmwf(nwp_flag, preproc_nwp_fnames%nwp_path_file(1), preproc_nwp_fnames%nwp_path_file2(1), &
-              preproc_nwp_fnames%nwp_path_file3(1), ecmwf, preproc_dims, preproc_geoloc, &
+         call read_ecmwf(nwp_flag, preproc_nwp_fnames, 1, ecmwf, preproc_dims, preproc_geoloc, &
               preproc_prtm, verbose)
       else
          call allocate_preproc_prtm(preproc_dims, preproc_prtm1)
-         call read_ecmwf(nwp_flag, preproc_nwp_fnames%nwp_path_file(1), preproc_nwp_fnames%nwp_path_file2(1), &
-              preproc_nwp_fnames%nwp_path_file3(1), ecmwf, preproc_dims, preproc_geoloc, &
+         call read_ecmwf(nwp_flag, preproc_nwp_fnames, 1, ecmwf, preproc_dims, preproc_geoloc, &
               preproc_prtm1, verbose)
 
          call allocate_preproc_prtm(preproc_dims, preproc_prtm2)
-         call read_ecmwf(nwp_flag, preproc_nwp_fnames%nwp_path_file(2), preproc_nwp_fnames%nwp_path_file2(2), &
-              preproc_nwp_fnames%nwp_path_file3(2), ecmwf, preproc_dims, preproc_geoloc, &
+         call read_ecmwf(nwp_flag, preproc_nwp_fnames, 2, ecmwf, preproc_dims, preproc_geoloc, &
               preproc_prtm2, verbose)
 
          call linearly_combine_prtms(1.-ecmwf_time_int_fac, ecmwf_time_int_fac, &

--- a/pre_processing/preparation.F90
+++ b/pre_processing/preparation.F90
@@ -121,11 +121,9 @@ subroutine preparation(paths, granule, opts, global_atts, orbit_number, &
       write(*,*) 'cminute: ',               trim(granule%cminute)
       write(*,*) 'orbit_number: ',          trim(orbit_number)
       write(*,*) 'ecmwf_path(1): ',         trim(opts%ecmwf_path(1))
-      write(*,*) 'ecmwf_path_hr(1): ',      trim(opts%ecmwf_path_hr(1))
       write(*,*) 'ecmwf_path2(1): ',        trim(opts%ecmwf_path2(1))
       write(*,*) 'ecmwf_path3(1): ',        trim(opts%ecmwf_path3(1))
       write(*,*) 'ecmwf_path(2): ',         trim(opts%ecmwf_path(2))
-      write(*,*) 'ecmwf_path_hr(2): ',      trim(opts%ecmwf_path_hr(2))
       write(*,*) 'ecmwf_path2(2): ',        trim(opts%ecmwf_path2(2))
       write(*,*) 'ecmwf_path3(2): ',        trim(opts%ecmwf_path3(2))
       write(*,*) 'ecmwf_flag: ',            ecmwf_flag
@@ -141,8 +139,6 @@ subroutine preparation(paths, granule, opts, global_atts, orbit_number, &
    if (verbose) then
       write(*,*) 'ecmwf_path_file:  ', trim(opts%ecmwf_path_file(1))
       write(*,*) 'ecmwf_path_file_2:  ', trim(opts%ecmwf_path_file(2))
-      write(*,*) 'ecmwf_hr_path_file:  ', trim(opts%ecmwf_hr_path_file(1))
-      write(*,*) 'ecmwf_hr_path_file2:  ', trim(opts%ecmwf_hr_path_file(2))
       if (ecmwf_flag .gt. 0.and.ecmwf_flag.lt.4) then
          write(*,*) 'ecmwf_path_file2: ', trim(opts%ecmwf_path_file2(1))
          write(*,*) 'ecmwf_path_file3: ', trim(opts%ecmwf_path_file3(1))

--- a/pre_processing/preparation.F90
+++ b/pre_processing/preparation.F90
@@ -18,7 +18,7 @@
 ! opts             struct both Processing options
 ! global_atts      struct in   Attributes for NCDF output
 ! orbit_number     strint in   Number of SLSTR orbit
-! ecmwf_flag       int    in   0: GRIB ECMWF files; 1: BADC NetCDF ECMWF files;
+! nwp_flag       int    in   0: GRIB ECMWF files; 1: BADC NetCDF ECMWF files;
 !                              2: BADC GRIB files.
 ! imager_geolocation struct in Summary of pixel positions
 ! imager_time      struct in   Time of observations
@@ -44,7 +44,7 @@
 ! 2014/02/03, AP: made badc a logical variable
 ! 2014/04/21, GM: Added logical option assume_full_path.
 ! 2014/05/01, GM: Reordered data/time arguments into a logical order.
-! 2014/05/02, AP: Made badc into ecmwf_flag.
+! 2014/05/02, AP: Made badc into nwp_flag.
 ! 2014/05/02, CP: Changed AATSR file naming
 ! 2015/08/08, CP: Added functionality for ATSR-2
 ! 2015/11/17, OS: Building high resolution ERA-Interim file name from low
@@ -59,7 +59,7 @@
 !    of the HR ERA data (copied from changes made, but committed to R3970
 !    version of code by CP).
 ! 2016/07/31, GM: Tidying of the code drop above.
-! 2017/04/11, SP: Added ecmwf_flag=6, for working with GFS analysis files.
+! 2017/04/11, SP: Added nwp_flag=6, for working with GFS analysis files.
 ! 2017/09/14, GT: Added product_name argument, which replaces the
 !    '-L2-CLOUD-CLD-' string in the output filenames
 ! 2018/02/01, GT: If a orbit number has been included in the source_attributes,
@@ -80,7 +80,7 @@ contains
 #include "set_ecmwf.F90"
 
 subroutine preparation(paths, granule, opts, global_atts, orbit_number, &
-     ecmwf_flag, imager_geolocation, imager_time, i_chunk, &
+     nwp_flag, imager_geolocation, imager_time, i_chunk, &
      time_int_fac, assume_full_path, verbose)
 
    use imager_structures_m
@@ -96,7 +96,7 @@ subroutine preparation(paths, granule, opts, global_atts, orbit_number, &
    type(preproc_opts_t),       intent(inout) :: opts
    type(global_attributes_t),  intent(in)    :: global_atts
    character(len=*),           intent(in)    :: orbit_number
-   integer,                    intent(in)    :: ecmwf_flag
+   integer,                    intent(in)    :: nwp_flag
    type(imager_geolocation_t), intent(in)    :: imager_geolocation
    type(imager_time_t),        intent(in)    :: imager_time
    integer,                    intent(in)    :: i_chunk
@@ -120,30 +120,30 @@ subroutine preparation(paths, granule, opts, global_atts, orbit_number, &
       write(*,*) 'chour: ',                 trim(granule%chour)
       write(*,*) 'cminute: ',               trim(granule%cminute)
       write(*,*) 'orbit_number: ',          trim(orbit_number)
-      write(*,*) 'ecmwf_path(1): ',         trim(opts%ecmwf_path(1))
-      write(*,*) 'ecmwf_path2(1): ',        trim(opts%ecmwf_path2(1))
-      write(*,*) 'ecmwf_path3(1): ',        trim(opts%ecmwf_path3(1))
-      write(*,*) 'ecmwf_path(2): ',         trim(opts%ecmwf_path(2))
-      write(*,*) 'ecmwf_path2(2): ',        trim(opts%ecmwf_path2(2))
-      write(*,*) 'ecmwf_path3(2): ',        trim(opts%ecmwf_path3(2))
-      write(*,*) 'ecmwf_flag: ',            ecmwf_flag
+      write(*,*) 'nwp_path(1): ',         trim(opts%nwp_path(1))
+      write(*,*) 'nwp_path2(1): ',        trim(opts%nwp_path2(1))
+      write(*,*) 'nwp_path3(1): ',        trim(opts%nwp_path3(1))
+      write(*,*) 'nwp_path(2): ',         trim(opts%nwp_path(2))
+      write(*,*) 'nwp_path2(2): ',        trim(opts%nwp_path2(2))
+      write(*,*) 'nwp_path3(2): ',        trim(opts%nwp_path3(2))
+      write(*,*) 'nwp_flag: ',            nwp_flag
       write(*,*) 'ecmwf_time_int_method: ', opts%ecmwf_time_int_method
       write(*,*) 'i_chunk: ',               i_chunk
       write(*,*) 'assume_full_path: ',      assume_full_path
    end if
 
    ! determine ecmwf path/filename
-   call set_ecmwf(granule, opts, ecmwf_flag, imager_geolocation, imager_time, &
+   call set_ecmwf(granule, opts, nwp_flag, imager_geolocation, imager_time, &
         time_int_fac, assume_full_path)
 
    if (verbose) then
-      write(*,*) 'ecmwf_path_file:  ', trim(opts%ecmwf_path_file(1))
-      write(*,*) 'ecmwf_path_file_2:  ', trim(opts%ecmwf_path_file(2))
-      if (ecmwf_flag .gt. 0.and.ecmwf_flag.lt.4) then
-         write(*,*) 'ecmwf_path_file2: ', trim(opts%ecmwf_path_file2(1))
-         write(*,*) 'ecmwf_path_file3: ', trim(opts%ecmwf_path_file3(1))
-         write(*,*) 'ecmwf_path_file2_2: ', trim(opts%ecmwf_path_file2(2))
-         write(*,*) 'ecmwf_path_file3_2: ', trim(opts%ecmwf_path_file3(2))
+      write(*,*) 'nwp_path_file:  ', trim(opts%nwp_path_file(1))
+      write(*,*) 'nwp_path_file_2:  ', trim(opts%nwp_path_file(2))
+      if (nwp_flag .gt. 0.and.nwp_flag.lt.4) then
+         write(*,*) 'nwp_path_file2: ', trim(opts%nwp_path_file2(1))
+         write(*,*) 'nwp_path_file3: ', trim(opts%nwp_path_file3(1))
+         write(*,*) 'nwp_path_file2_2: ', trim(opts%nwp_path_file2(2))
+         write(*,*) 'nwp_path_file3_2: ', trim(opts%nwp_path_file3(2))
       end if
    end if
 

--- a/pre_processing/preparation.F90
+++ b/pre_processing/preparation.F90
@@ -79,14 +79,14 @@ contains
 
 #include "set_ecmwf.F90"
 
-subroutine preparation(paths, granule, opts, global_atts, orbit_number, &
+subroutine preparation(paths, granule, opts, nwp_fnames, global_atts, orbit_number, &
      nwp_flag, imager_geolocation, imager_time, i_chunk, &
      time_int_fac, assume_full_path, verbose)
 
    use imager_structures_m
    use global_attributes_m
    use preproc_constants_m
-   use preproc_structures_m, only: preproc_opts_t, preproc_paths_t
+   use preproc_structures_m, only: preproc_nwp_fnames_t, preproc_opts_t, preproc_paths_t
    use setup_m, only: setup_args_t
 
    implicit none
@@ -94,6 +94,7 @@ subroutine preparation(paths, granule, opts, global_atts, orbit_number, &
    type(preproc_paths_t),      intent(out)   :: paths
    type(setup_args_t),         intent(in)    :: granule
    type(preproc_opts_t),       intent(inout) :: opts
+   type(preproc_nwp_fnames_t), intent(inout) :: nwp_fnames
    type(global_attributes_t),  intent(in)    :: global_atts
    character(len=*),           intent(in)    :: orbit_number
    integer,                    intent(in)    :: nwp_flag
@@ -120,12 +121,12 @@ subroutine preparation(paths, granule, opts, global_atts, orbit_number, &
       write(*,*) 'chour: ',                 trim(granule%chour)
       write(*,*) 'cminute: ',               trim(granule%cminute)
       write(*,*) 'orbit_number: ',          trim(orbit_number)
-      write(*,*) 'nwp_path(1): ',         trim(opts%nwp_path(1))
-      write(*,*) 'nwp_path2(1): ',        trim(opts%nwp_path2(1))
-      write(*,*) 'nwp_path3(1): ',        trim(opts%nwp_path3(1))
-      write(*,*) 'nwp_path(2): ',         trim(opts%nwp_path(2))
-      write(*,*) 'nwp_path2(2): ',        trim(opts%nwp_path2(2))
-      write(*,*) 'nwp_path3(2): ',        trim(opts%nwp_path3(2))
+      write(*,*) 'nwp_path(1): ',         trim(nwp_fnames%nwp_path(1))
+      write(*,*) 'nwp_path2(1): ',        trim(nwp_fnames%nwp_path2(1))
+      write(*,*) 'nwp_path3(1): ',        trim(nwp_fnames%nwp_path3(1))
+      write(*,*) 'nwp_path(2): ',         trim(nwp_fnames%nwp_path(2))
+      write(*,*) 'nwp_path2(2): ',        trim(nwp_fnames%nwp_path2(2))
+      write(*,*) 'nwp_path3(2): ',        trim(nwp_fnames%nwp_path3(2))
       write(*,*) 'nwp_flag: ',            nwp_flag
       write(*,*) 'ecmwf_time_int_method: ', opts%ecmwf_time_int_method
       write(*,*) 'i_chunk: ',               i_chunk
@@ -133,17 +134,17 @@ subroutine preparation(paths, granule, opts, global_atts, orbit_number, &
    end if
 
    ! determine ecmwf path/filename
-   call set_ecmwf(granule, opts, nwp_flag, imager_geolocation, imager_time, &
+   call set_ecmwf(granule, opts, nwp_fnames, nwp_flag, imager_geolocation, imager_time, &
         time_int_fac, assume_full_path)
 
    if (verbose) then
-      write(*,*) 'nwp_path_file:  ', trim(opts%nwp_path_file(1))
-      write(*,*) 'nwp_path_file_2:  ', trim(opts%nwp_path_file(2))
+      write(*,*) 'nwp_path_file:  ', trim(nwp_fnames%nwp_path_file(1))
+      write(*,*) 'nwp_path_file_2:  ', trim(nwp_fnames%nwp_path_file(2))
       if (nwp_flag .gt. 0.and.nwp_flag.lt.4) then
-         write(*,*) 'nwp_path_file2: ', trim(opts%nwp_path_file2(1))
-         write(*,*) 'nwp_path_file3: ', trim(opts%nwp_path_file3(1))
-         write(*,*) 'nwp_path_file2_2: ', trim(opts%nwp_path_file2(2))
-         write(*,*) 'nwp_path_file3_2: ', trim(opts%nwp_path_file3(2))
+         write(*,*) 'nwp_path_file2: ', trim(nwp_fnames%nwp_path_file2(1))
+         write(*,*) 'nwp_path_file3: ', trim(nwp_fnames%nwp_path_file3(1))
+         write(*,*) 'nwp_path_file2_2: ', trim(nwp_fnames%nwp_path_file2(2))
+         write(*,*) 'nwp_path_file3_2: ', trim(nwp_fnames%nwp_path_file3(2))
       end if
    end if
 

--- a/pre_processing/preproc_structures.F90
+++ b/pre_processing/preproc_structures.F90
@@ -75,10 +75,11 @@ module preproc_structures_m
       logical                    :: do_cloud_emis
       logical                    :: do_cloud_type
       logical                    :: do_ironly
-      integer                    :: ecmwf_nlevels
+      integer                    :: nwp_nlevels
       integer                    :: ecmwf_time_int_method
       integer, pointer           :: channel_ids(:)
       integer(kind=lint)         :: n_channels
+      integer                    :: nwp_time_factor
       real                       :: swansea_gamma
       logical                    :: use_camel_emis
       logical                    :: use_ecmwf_snow_and_ice
@@ -89,12 +90,12 @@ module preproc_structures_m
       logical                    :: use_predef_lsm
       logical                    :: use_swansea_climatology
 
-      character(len=path_length) :: ecmwf_path(2)
-      character(len=path_length) :: ecmwf_path2(2)
-      character(len=path_length) :: ecmwf_path3(2)
-      character(len=path_length) :: ecmwf_path_file(2)
-      character(len=path_length) :: ecmwf_path_file2(2)
-      character(len=path_length) :: ecmwf_path_file3(2)
+      character(len=path_length) :: nwp_path(2)
+      character(len=path_length) :: nwp_path2(2)
+      character(len=path_length) :: nwp_path3(2)
+      character(len=path_length) :: nwp_path_file(2)
+      character(len=path_length) :: nwp_path_file2(2)
+      character(len=path_length) :: nwp_path_file3(2)
       character(len=path_length) :: ext_lsm_path
       character(len=path_length) :: ext_geo_path
       character(len=path_length) :: occci_path

--- a/pre_processing/preproc_structures.F90
+++ b/pre_processing/preproc_structures.F90
@@ -64,6 +64,38 @@ module preproc_structures_m
    type preproc_geo_t
       real(kind=sreal), dimension(:,:,:), pointer :: solza,solazi,satza,satazi,relazi
    end type preproc_geo_t
+   
+   ! NWP filenames
+   type preproc_nwp_fnames_t
+
+      character(len=path_length) :: nwp_path(2)
+      character(len=path_length) :: nwp_path2(2)
+      character(len=path_length) :: nwp_path3(2)
+      character(len=path_length) :: nwp_path_file(2)
+      character(len=path_length) :: nwp_path_file2(2)
+      character(len=path_length) :: nwp_path_file3(2)
+      
+      character(len=path_length) :: q_f(2)       ! Specific humidity on model levels
+      character(len=path_length) :: t_f(2)       ! Temperature on model levels
+      character(len=path_length) :: o3_f(2)      ! Ozone on model levels
+      character(len=path_length) :: p_f(2)       ! Pressure on model levels
+      character(len=path_length) :: u_f(2)       ! U-compoonent of wind on model levels
+      character(len=path_length) :: v_f(2)       ! V-component of wind on model levels
+      character(len=path_length) :: z_f(2)       ! Geopotential at surface
+      character(len=path_length) :: lnsp_f(2)    ! Logarithm of surface pressure
+      character(len=path_length) :: ci_f(2)      ! Sea ice fraction
+      character(len=path_length) :: asn_f(2)     ! Snow albedo
+      character(len=path_length) :: tcwv_f(2)    ! Total column water vapor
+      character(len=path_length) :: sd_f(2)      ! Snow depth
+      character(len=path_length) :: u10_f(2)     ! 10m U-component of wind speed
+      character(len=path_length) :: v10_f(2)     ! 10m V-component of wind speed
+      character(len=path_length) :: t2_f(2)      ! 2m air temperature
+      character(len=path_length) :: skt_f(2)     ! Skin temperature
+      character(len=path_length) :: sstk_f(2)    ! Sea surface temperature
+      character(len=path_length) :: al_f(2)      ! Surface albedo
+      character(len=path_length) :: cape_f(2)    ! Convective available potential energy
+   
+   end type preproc_nwp_fnames_t
 
 
    ! optional processing variables, typically defined through the driver file
@@ -89,13 +121,7 @@ module preproc_structures_m
       logical                    :: use_predef_geo
       logical                    :: use_predef_lsm
       logical                    :: use_swansea_climatology
-
-      character(len=path_length) :: nwp_path(2)
-      character(len=path_length) :: nwp_path2(2)
-      character(len=path_length) :: nwp_path3(2)
-      character(len=path_length) :: nwp_path_file(2)
-      character(len=path_length) :: nwp_path_file2(2)
-      character(len=path_length) :: nwp_path_file3(2)
+      
       character(len=path_length) :: ext_lsm_path
       character(len=path_length) :: ext_geo_path
       character(len=path_length) :: occci_path

--- a/pre_processing/preproc_structures.F90
+++ b/pre_processing/preproc_structures.F90
@@ -82,7 +82,6 @@ module preproc_structures_m
       real                       :: swansea_gamma
       logical                    :: use_camel_emis
       logical                    :: use_ecmwf_snow_and_ice
-      logical                    :: use_hr_ecmwf
       logical                    :: use_l1_land_mask
       logical                    :: use_modis_emis_in_rttov
       logical                    :: use_occci
@@ -93,8 +92,6 @@ module preproc_structures_m
       character(len=path_length) :: ecmwf_path(2)
       character(len=path_length) :: ecmwf_path2(2)
       character(len=path_length) :: ecmwf_path3(2)
-      character(len=path_length) :: ecmwf_path_hr(2)
-      character(len=path_length) :: ecmwf_HR_path_file(2)
       character(len=path_length) :: ecmwf_path_file(2)
       character(len=path_length) :: ecmwf_path_file2(2)
       character(len=path_length) :: ecmwf_path_file3(2)

--- a/pre_processing/preproc_structures.F90
+++ b/pre_processing/preproc_structures.F90
@@ -78,7 +78,6 @@ module preproc_structures_m
       character(len=path_length) :: q_f(2)       ! Specific humidity on model levels
       character(len=path_length) :: t_f(2)       ! Temperature on model levels
       character(len=path_length) :: o3_f(2)      ! Ozone on model levels
-      character(len=path_length) :: p_f(2)       ! Pressure on model levels
       character(len=path_length) :: u_f(2)       ! U-compoonent of wind on model levels
       character(len=path_length) :: v_f(2)       ! V-component of wind on model levels
       character(len=path_length) :: z_f(2)       ! Geopotential at surface
@@ -92,7 +91,6 @@ module preproc_structures_m
       character(len=path_length) :: t2_f(2)      ! 2m air temperature
       character(len=path_length) :: skt_f(2)     ! Skin temperature
       character(len=path_length) :: sstk_f(2)    ! Sea surface temperature
-      character(len=path_length) :: al_f(2)      ! Surface albedo
       character(len=path_length) :: cape_f(2)    ! Convective available potential energy
    
    end type preproc_nwp_fnames_t

--- a/pre_processing/read_ecmwf.F90
+++ b/pre_processing/read_ecmwf.F90
@@ -34,8 +34,8 @@
 ! None known.
 !-------------------------------------------------------------------------------
 
-subroutine read_ecmwf_wind(ecmwf_flag, ecmwf_path_file, ecmwf_HR_path_file, &
-   ecmwf_path_file2, ecmwf_path_file3, ecmwf, ecmwf_HR, use_hr_ecmwf, &
+subroutine read_ecmwf_wind(ecmwf_flag, ecmwf_path_file, &
+   ecmwf_path_file2, ecmwf_path_file3, ecmwf, &
    ecmwf_nlevels, verbose)
 
    use preproc_structures_m
@@ -44,12 +44,9 @@ subroutine read_ecmwf_wind(ecmwf_flag, ecmwf_path_file, ecmwf_HR_path_file, &
 
    integer,          intent(in)    :: ecmwf_flag
    character(len=*), intent(in)    :: ecmwf_path_file
-   character(len=*), intent(in)    :: ecmwf_HR_path_file
    character(len=*), intent(in)    :: ecmwf_path_file2
    character(len=*), intent(in)    :: ecmwf_path_file3
    type(ecmwf_t),    intent(inout) :: ecmwf
-   type(ecmwf_t),    intent(inout) :: ecmwf_HR
-   logical,          intent(in)    :: use_hr_ecmwf
    integer,          intent(in)    :: ecmwf_nlevels
    logical,          intent(in)    :: verbose
 
@@ -71,41 +68,23 @@ subroutine read_ecmwf_wind(ecmwf_flag, ecmwf_path_file, ecmwf_HR_path_file, &
    case(0)
       call read_ecmwf_wind_grib(ecmwf_path_file, ecmwf, .false., ecmwf_flag)
       if (verbose) write(*,*)'ecmwf_dims grib: ', ecmwf%xdim, ecmwf%ydim
-      if (use_hr_ecmwf) then
-         call read_ecmwf_wind_grib(ecmwf_HR_path_file, ecmwf_HR, .true., ecmwf_flag)
-      end if
    case(1)
       call read_ecmwf_wind_nc(ecmwf, ecmwf_path_file, ecmwf_flag, ecmwf_path_file2, &
            ecmwf_path_file3)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim
-      if (use_hr_ecmwf) then
-         call read_ecmwf_wind_grib(ecmwf_HR_path_file, ecmwf_HR, .true., ecmwf_flag)
-      end if
    case(2)
       call read_ecmwf_wind_badc(ecmwf_path_file, ecmwf_path_file2, &
            ecmwf_path_file3, ecmwf)
       if (verbose) write(*,*)'ecmwf_dims badc: ', ecmwf%xdim, ecmwf%ydim
-      if (use_hr_ecmwf) then
-         call read_ecmwf_wind_grib(ecmwf_HR_path_file, ecmwf_HR, .true., ecmwf_flag)
-      end if
    case(3)
       call read_ecmwf_wind_nc(ecmwf, ecmwf_path_file, ecmwf_flag)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim, ecmwf%kdim
-      if (use_hr_ecmwf) then
-         call read_ecmwf_wind_nc(ecmwf_HR, ecmwf_HR_path_file, ecmwf_flag)
-      end if
    case(4)
       call read_ecmwf_wind_nc(ecmwf, ecmwf_path_file, ecmwf_flag)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim
-      if (use_hr_ecmwf) then
-         call read_ecmwf_wind_nc(ecmwf_HR, ecmwf_HR_path_file, ecmwf_flag)
-      end if
    case(5)
       call read_ecmwf_wind_nc(ecmwf, ecmwf_path_file, ecmwf_flag)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim
-      if (use_hr_ecmwf) then
-         call read_ecmwf_wind_nc(ecmwf_HR, ecmwf_HR_path_file, ecmwf_flag)
-      end if
    case(6)
       call read_ecmwf_wind_grib(ecmwf_path_file, ecmwf, .false., ecmwf_flag)
       if (verbose) write(*,*)'ecmwf_dims grib: ', ecmwf%xdim, ecmwf%ydim
@@ -130,16 +109,8 @@ subroutine read_ecmwf_wind(ecmwf_flag, ecmwf_path_file, ecmwf_HR_path_file, &
    ! and 9999.0 for Ox/RAL.  Here we set it to ORAC's value.
    where (ecmwf%sea_ice_cover .lt. 0.0 .or. ecmwf%sea_ice_cover .gt. 1.0) &
       ecmwf%sea_ice_cover = sreal_fill_value
-   if (use_hr_ecmwf) then
-      where (ecmwf_HR%sea_ice_cover .lt. 0.0 .or. &
-             ecmwf_HR%sea_ice_cover .gt. 1.0) &
-         ecmwf_HR%sea_ice_cover = sreal_fill_value
-   end if
 
-   call rearrange_ecmwf(ecmwf, .false.)
-   if (use_hr_ecmwf) then
-      call rearrange_ecmwf(ecmwf_HR, .true.)
-   end if
+   call rearrange_ecmwf(ecmwf)
 
 end subroutine read_ecmwf_wind
 

--- a/pre_processing/read_ecmwf.F90
+++ b/pre_processing/read_ecmwf.F90
@@ -23,35 +23,35 @@
 ! 2016/02/03, GM: Set the fill_value for sea_ice_cover to sreal_fill_value.
 ! 2016/04/03, SP: Add option to process ECMWF forecast in single NetCDF4 file
 !    Note: This should work with either the OPER or FCST streams from ECMWF.
-! 2016/04/26, AP: There are no high res files compatible with ecmwf_flag=1.
+! 2016/04/26, AP: There are no high res files compatible with nwp_flag=1.
 !    Merge _dwd routines with _nc.
-! 2017/02/04, SP: Add ecmwf_flag=5, for reading NOAA GFS forecast (ExtWork)
-! 2017/04/11, SP: Added ecmwf_flag=6, for working with GFS analysis files.
+! 2017/02/04, SP: Add nwp_flag=5, for reading NOAA GFS forecast (ExtWork)
+! 2017/04/11, SP: Added nwp_flag=6, for working with GFS analysis files.
 ! 2017/06/21, OS: inout declaration bug fix for cray-fortran compiler
-! 2018/11/05, SP: Switch ecmwf_flag=5 from GFS (dead code) to ECMWF ERA5
+! 2018/11/05, SP: Switch nwp_flag=5 from GFS (dead code) to ECMWF ERA5
 !
 ! Bugs:
 ! None known.
 !-------------------------------------------------------------------------------
 
-subroutine read_ecmwf_wind(ecmwf_flag, ecmwf_path_file, &
-   ecmwf_path_file2, ecmwf_path_file3, ecmwf, &
-   ecmwf_nlevels, verbose)
+subroutine read_ecmwf_wind(nwp_flag, nwp_path_file, &
+   nwp_path_file2, nwp_path_file3, ecmwf, &
+   nwp_nlevels, verbose)
 
    use preproc_structures_m
 
    implicit none
 
-   integer,          intent(in)    :: ecmwf_flag
-   character(len=*), intent(in)    :: ecmwf_path_file
-   character(len=*), intent(in)    :: ecmwf_path_file2
-   character(len=*), intent(in)    :: ecmwf_path_file3
+   integer,          intent(in)    :: nwp_flag
+   character(len=*), intent(in)    :: nwp_path_file
+   character(len=*), intent(in)    :: nwp_path_file2
+   character(len=*), intent(in)    :: nwp_path_file3
    type(ecmwf_t),    intent(inout) :: ecmwf
-   integer,          intent(in)    :: ecmwf_nlevels
+   integer,          intent(in)    :: nwp_nlevels
    logical,          intent(in)    :: verbose
 
    ! Set the number of levels in the input file, defaults to 61
-   select case(ecmwf_nlevels)
+   select case(nwp_nlevels)
    case(31)
       ecmwf%kdim = 31
    case(60)
@@ -64,35 +64,35 @@ subroutine read_ecmwf_wind(ecmwf_flag, ecmwf_path_file, &
       ecmwf%kdim = 60
    end select
 
-   select case (ecmwf_flag)
+   select case (nwp_flag)
    case(0)
-      call read_ecmwf_wind_grib(ecmwf_path_file, ecmwf, .false., ecmwf_flag)
+      call read_ecmwf_wind_grib(nwp_path_file, ecmwf, .false., nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims grib: ', ecmwf%xdim, ecmwf%ydim
    case(1)
-      call read_ecmwf_wind_nc(ecmwf, ecmwf_path_file, ecmwf_flag, ecmwf_path_file2, &
-           ecmwf_path_file3)
+      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag, nwp_path_file2, &
+           nwp_path_file3)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim
    case(2)
-      call read_ecmwf_wind_badc(ecmwf_path_file, ecmwf_path_file2, &
-           ecmwf_path_file3, ecmwf)
+      call read_ecmwf_wind_badc(nwp_path_file, nwp_path_file2, &
+           nwp_path_file3, ecmwf)
       if (verbose) write(*,*)'ecmwf_dims badc: ', ecmwf%xdim, ecmwf%ydim
    case(3)
-      call read_ecmwf_wind_nc(ecmwf, ecmwf_path_file, ecmwf_flag)
+      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim, ecmwf%kdim
    case(4)
-      call read_ecmwf_wind_nc(ecmwf, ecmwf_path_file, ecmwf_flag)
+      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim
    case(5)
-      call read_ecmwf_wind_nc(ecmwf, ecmwf_path_file, ecmwf_flag)
+      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim
    case(6)
-      call read_ecmwf_wind_grib(ecmwf_path_file, ecmwf, .false., ecmwf_flag)
+      call read_ecmwf_wind_grib(nwp_path_file, ecmwf, .false., nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims grib: ', ecmwf%xdim, ecmwf%ydim
    case(7)
-      call read_ecmwf_wind_grib(ecmwf_path_file, ecmwf, .false., ecmwf_flag)
+      call read_ecmwf_wind_grib(nwp_path_file, ecmwf, .false., nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims grib: ', ecmwf%xdim, ecmwf%ydim
    case(8)
-      call read_ecmwf_wind_nc(ecmwf, ecmwf_path_file, ecmwf_flag)
+      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims grib: ', ecmwf%xdim, ecmwf%ydim
    case default
       write(*,*) "Incorrect ECMWF flag, must be between 0-8."
@@ -140,76 +140,76 @@ end subroutine read_ecmwf_wind
 ! None known.
 !-------------------------------------------------------------------------------
 
-subroutine read_ecmwf(ecmwf_flag, ecmwf_path_file, ecmwf_path_file2, &
-   ecmwf_path_file3, ecmwf, preproc_dims, preproc_geoloc, preproc_prtm, verbose)
+subroutine read_ecmwf(nwp_flag, nwp_path_file, nwp_path_file2, &
+   nwp_path_file3, ecmwf, preproc_dims, preproc_geoloc, preproc_prtm, verbose)
 
    use preproc_structures_m
 
    implicit none
 
-   integer,                intent(in)    :: ecmwf_flag
-   character(len=*),       intent(in)    :: ecmwf_path_file
-   character(len=*),       intent(in)    :: ecmwf_path_file2
-   character(len=*),       intent(in)    :: ecmwf_path_file3
+   integer,                intent(in)    :: nwp_flag
+   character(len=*),       intent(in)    :: nwp_path_file
+   character(len=*),       intent(in)    :: nwp_path_file2
+   character(len=*),       intent(in)    :: nwp_path_file3
    type(ecmwf_t),          intent(in)    :: ecmwf
    type(preproc_dims_t),   intent(in)    :: preproc_dims
    type(preproc_geoloc_t), intent(in)    :: preproc_geoloc
    type(preproc_prtm_t),   intent(inout) :: preproc_prtm
    logical,                intent(in)    :: verbose
 
-   select case (ecmwf_flag)
+   select case (nwp_flag)
    case(0)
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(ecmwf_path_file)
-      call read_ecmwf_grib(ecmwf_path_file, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file)
+      call read_ecmwf_grib(nwp_path_file, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose)
    case(1)
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(ecmwf_path_file)
-      call read_ecmwf_nc(ecmwf_path_file, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, ecmwf_flag)
+      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file)
+      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
+           preproc_prtm, verbose, nwp_flag)
 
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(ecmwf_path_file2)
-      call read_ecmwf_nc(ecmwf_path_file2, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, ecmwf_flag)
+      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file2)
+      call read_ecmwf_nc(nwp_path_file2, ecmwf, preproc_dims, preproc_geoloc, &
+           preproc_prtm, verbose, nwp_flag)
 
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(ecmwf_path_file3)
-      call read_ecmwf_nc(ecmwf_path_file3, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, ecmwf_flag)
+      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file3)
+      call read_ecmwf_nc(nwp_path_file3, ecmwf, preproc_dims, preproc_geoloc, &
+           preproc_prtm, verbose, nwp_flag)
    case(2)
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(ecmwf_path_file)
-      call read_ecmwf_nc(ecmwf_path_file, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, ecmwf_flag)
+      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file)
+      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
+           preproc_prtm, verbose, nwp_flag)
 
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(ecmwf_path_file2)
-      call read_ecmwf_grib(ecmwf_path_file2, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file2)
+      call read_ecmwf_grib(nwp_path_file2, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose)
 
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(ecmwf_path_file3)
-      call read_ecmwf_grib(ecmwf_path_file3, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file3)
+      call read_ecmwf_grib(nwp_path_file3, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose)
    case(3)
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(ecmwf_path_file)
-      call read_ecmwf_nc(ecmwf_path_file, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, ecmwf_flag)
+      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file)
+      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
+           preproc_prtm, verbose, nwp_flag)
    case(4)
-      if (verbose) write(*,*) 'Reading OPER path: ', trim(ecmwf_path_file)
-      call read_ecmwf_nc(ecmwf_path_file, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, ecmwf_flag)
+      if (verbose) write(*,*) 'Reading OPER path: ', trim(nwp_path_file)
+      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
+           preproc_prtm, verbose, nwp_flag)
    case(5)
-      if (verbose) write(*,*) 'Reading ERA5 path: ', trim(ecmwf_path_file)
-      call read_ecmwf_nc(ecmwf_path_file, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, ecmwf_flag)
+      if (verbose) write(*,*) 'Reading ERA5 path: ', trim(nwp_path_file)
+      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
+           preproc_prtm, verbose, nwp_flag)
    case(6)
-      if (verbose) write(*,*) 'Reading gfs path: ', trim(ecmwf_path_file)
-      call read_gfs_grib(ecmwf_path_file, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading gfs path: ', trim(nwp_path_file)
+      call read_gfs_grib(nwp_path_file, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose)
    case(7)
-      if (verbose) write(*,*) 'Reading gfs path: ', trim(ecmwf_path_file)
-      call read_gfs_grib(ecmwf_path_file, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading gfs path: ', trim(nwp_path_file)
+      call read_gfs_grib(nwp_path_file, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose)
    case(8)
-      if (verbose) write(*,*) 'Reading gfs path: ', trim(ecmwf_path_file)
-      call read_gfs_nc(ecmwf_path_file, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, ecmwf_flag)
+      if (verbose) write(*,*) 'Reading gfs path: ', trim(nwp_path_file)
+      call read_gfs_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
+           preproc_prtm, verbose, nwp_flag)
    end select
 
 

--- a/pre_processing/read_ecmwf.F90
+++ b/pre_processing/read_ecmwf.F90
@@ -69,33 +69,20 @@ subroutine read_ecmwf_wind(nwp_flag, nwp_path_file, &
       call read_ecmwf_wind_grib(nwp_path_file, ecmwf, .false., nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims grib: ', ecmwf%xdim, ecmwf%ydim
    case(1)
-      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag, nwp_path_file2, &
-           nwp_path_file3)
+      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim
    case(2)
-      call read_ecmwf_wind_badc(nwp_path_file, nwp_path_file2, &
-           nwp_path_file3, ecmwf)
-      if (verbose) write(*,*)'ecmwf_dims badc: ', ecmwf%xdim, ecmwf%ydim
+      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
+      if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim
    case(3)
       call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim, ecmwf%kdim
    case(4)
-      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
-      if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim
-   case(5)
-      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
-      if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim
-   case(6)
-      call read_ecmwf_wind_grib(nwp_path_file, ecmwf, .false., nwp_flag)
-      if (verbose) write(*,*)'ecmwf_dims grib: ', ecmwf%xdim, ecmwf%ydim
-   case(7)
-      call read_ecmwf_wind_grib(nwp_path_file, ecmwf, .false., nwp_flag)
-      if (verbose) write(*,*)'ecmwf_dims grib: ', ecmwf%xdim, ecmwf%ydim
-   case(8)
-      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
-      if (verbose) write(*,*)'ecmwf_dims grib: ', ecmwf%xdim, ecmwf%ydim
+      call read_ecmwf_wind_badc(nwp_path_file, nwp_path_file2, &
+           nwp_path_file3, ecmwf)
+      if (verbose) write(*,*)'ecmwf_dims badc: ', ecmwf%xdim, ecmwf%ydim
    case default
-      write(*,*) "Incorrect ECMWF flag, must be between 0-8."
+      write(*,*) "Incorrect ECMWF flag, must be between 0-4."
       stop
    end select
    if (verbose) then
@@ -159,22 +146,22 @@ subroutine read_ecmwf(nwp_flag, nwp_path_file, nwp_path_file2, &
 
    select case (nwp_flag)
    case(0)
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file)
-      call read_ecmwf_grib(nwp_path_file, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading gfs path: ', trim(nwp_path_file)
+      call read_gfs_grib(nwp_path_file, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose)
    case(1)
+      if (verbose) write(*,*) 'Reading ECMWF path: ', trim(nwp_path_file)
+      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
+           preproc_prtm, verbose, nwp_flag)
+   case(2)
+      if (verbose) write(*,*) 'Reading JASMIN ERA5 path: ', trim(nwp_path_file)
+      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
+           preproc_prtm, verbose, nwp_flag)
+   case(3)
       if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file)
       call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose, nwp_flag)
-
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file2)
-      call read_ecmwf_nc(nwp_path_file2, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, nwp_flag)
-
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file3)
-      call read_ecmwf_nc(nwp_path_file3, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, nwp_flag)
-   case(2)
+   case(4)
       if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file)
       call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose, nwp_flag)
@@ -186,30 +173,6 @@ subroutine read_ecmwf(nwp_flag, nwp_path_file, nwp_path_file2, &
       if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file3)
       call read_ecmwf_grib(nwp_path_file3, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose)
-   case(3)
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file)
-      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, nwp_flag)
-   case(4)
-      if (verbose) write(*,*) 'Reading OPER path: ', trim(nwp_path_file)
-      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, nwp_flag)
-   case(5)
-      if (verbose) write(*,*) 'Reading ERA5 path: ', trim(nwp_path_file)
-      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, nwp_flag)
-   case(6)
-      if (verbose) write(*,*) 'Reading gfs path: ', trim(nwp_path_file)
-      call read_gfs_grib(nwp_path_file, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose)
-   case(7)
-      if (verbose) write(*,*) 'Reading gfs path: ', trim(nwp_path_file)
-      call read_gfs_grib(nwp_path_file, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose)
-   case(8)
-      if (verbose) write(*,*) 'Reading gfs path: ', trim(nwp_path_file)
-      call read_gfs_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
-           preproc_prtm, verbose, nwp_flag)
    end select
 
 

--- a/pre_processing/read_ecmwf.F90
+++ b/pre_processing/read_ecmwf.F90
@@ -34,22 +34,20 @@
 ! None known.
 !-------------------------------------------------------------------------------
 
-subroutine read_ecmwf_wind(nwp_flag, nwp_path_file, &
-   nwp_path_file2, nwp_path_file3, ecmwf, &
+subroutine read_ecmwf_wind(nwp_flag, nwp_fnames, idx, ecmwf, &
    nwp_nlevels, verbose)
 
    use preproc_structures_m
 
    implicit none
 
-   integer,          intent(in)    :: nwp_flag
-   character(len=*), intent(in)    :: nwp_path_file
-   character(len=*), intent(in)    :: nwp_path_file2
-   character(len=*), intent(in)    :: nwp_path_file3
-   type(ecmwf_t),    intent(inout) :: ecmwf
-   integer,          intent(in)    :: nwp_nlevels
-   logical,          intent(in)    :: verbose
-
+   integer,          intent(in)              :: nwp_flag
+   type(preproc_nwp_fnames_t), intent(inout) :: nwp_fnames
+   integer,          intent(in)              :: idx
+   type(ecmwf_t),    intent(inout)           :: ecmwf
+   integer,          intent(in)              :: nwp_nlevels
+   logical,          intent(in)              :: verbose
+   
    ! Set the number of levels in the input file, defaults to 61
    select case(nwp_nlevels)
    case(31)
@@ -66,20 +64,20 @@ subroutine read_ecmwf_wind(nwp_flag, nwp_path_file, &
 
    select case (nwp_flag)
    case(0)
-      call read_ecmwf_wind_grib(nwp_path_file, ecmwf, .false., nwp_flag)
+      call read_ecmwf_wind_grib(nwp_fnames%nwp_path_file(idx), ecmwf, .false., nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims grib: ', ecmwf%xdim, ecmwf%ydim
    case(1)
-      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
+      call read_ecmwf_wind_nc(ecmwf, nwp_fnames%nwp_path_file(idx), nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim
    case(2)
-      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
+      call read_era5_jasmin_wind_nc(ecmwf, nwp_fnames, idx, nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim
    case(3)
-      call read_ecmwf_wind_nc(ecmwf, nwp_path_file, nwp_flag)
+      call read_ecmwf_wind_nc(ecmwf, nwp_fnames%nwp_path_file(idx), nwp_flag)
       if (verbose) write(*,*)'ecmwf_dims ncdf: ', ecmwf%xdim, ecmwf%ydim, ecmwf%kdim
    case(4)
-      call read_ecmwf_wind_badc(nwp_path_file, nwp_path_file2, &
-           nwp_path_file3, ecmwf)
+      call read_ecmwf_wind_badc(nwp_fnames%nwp_path_file(idx), nwp_fnames%nwp_path_file2(idx), &
+           nwp_fnames%nwp_path_file3(idx), ecmwf)
       if (verbose) write(*,*)'ecmwf_dims badc: ', ecmwf%xdim, ecmwf%ydim
    case default
       write(*,*) "Incorrect ECMWF flag, must be between 0-4."
@@ -127,51 +125,50 @@ end subroutine read_ecmwf_wind
 ! None known.
 !-------------------------------------------------------------------------------
 
-subroutine read_ecmwf(nwp_flag, nwp_path_file, nwp_path_file2, &
-   nwp_path_file3, ecmwf, preproc_dims, preproc_geoloc, preproc_prtm, verbose)
+subroutine read_ecmwf(nwp_flag,nwp_fnames, idx, ecmwf, preproc_dims, &
+                      preproc_geoloc, preproc_prtm, verbose)
 
    use preproc_structures_m
 
    implicit none
 
-   integer,                intent(in)    :: nwp_flag
-   character(len=*),       intent(in)    :: nwp_path_file
-   character(len=*),       intent(in)    :: nwp_path_file2
-   character(len=*),       intent(in)    :: nwp_path_file3
-   type(ecmwf_t),          intent(in)    :: ecmwf
-   type(preproc_dims_t),   intent(in)    :: preproc_dims
-   type(preproc_geoloc_t), intent(in)    :: preproc_geoloc
-   type(preproc_prtm_t),   intent(inout) :: preproc_prtm
-   logical,                intent(in)    :: verbose
+   integer,                intent(in)        :: nwp_flag
+   type(preproc_nwp_fnames_t), intent(inout) :: nwp_fnames
+   integer,          intent(in)              :: idx
+   type(ecmwf_t),          intent(in)        :: ecmwf
+   type(preproc_dims_t),   intent(in)        :: preproc_dims
+   type(preproc_geoloc_t), intent(in)        :: preproc_geoloc
+   type(preproc_prtm_t),   intent(inout)     :: preproc_prtm
+   logical,                intent(in)        :: verbose
 
    select case (nwp_flag)
    case(0)
-      if (verbose) write(*,*) 'Reading gfs path: ', trim(nwp_path_file)
-      call read_gfs_grib(nwp_path_file, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading gfs path: ', trim(nwp_fnames%nwp_path_file(idx))
+      call read_gfs_grib(nwp_fnames%nwp_path_file(idx), preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose)
    case(1)
-      if (verbose) write(*,*) 'Reading ECMWF path: ', trim(nwp_path_file)
-      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading ECMWF path: ', trim(nwp_fnames%nwp_path_file(idx))
+      call read_ecmwf_nc(nwp_fnames%nwp_path_file(idx), ecmwf, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose, nwp_flag)
    case(2)
-      if (verbose) write(*,*) 'Reading JASMIN ERA5 path: ', trim(nwp_path_file)
-      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading JASMIN ERA5 path: ', trim(nwp_fnames%nwp_path_file(idx))
+      call read_era5_jasmin_nc(nwp_fnames, idx, ecmwf, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose, nwp_flag)
    case(3)
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file)
-      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_fnames%nwp_path_file(idx))
+      call read_ecmwf_nc(nwp_fnames%nwp_path_file(idx), ecmwf, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose, nwp_flag)
    case(4)
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file)
-      call read_ecmwf_nc(nwp_path_file, ecmwf, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_fnames%nwp_path_file(idx))
+      call read_ecmwf_nc(nwp_fnames%nwp_path_file(idx), ecmwf, preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose, nwp_flag)
 
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file2)
-      call read_ecmwf_grib(nwp_path_file2, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_fnames%nwp_path_file2(idx))
+      call read_ecmwf_grib(nwp_fnames%nwp_path_file2(idx), preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose)
 
-      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_path_file3)
-      call read_ecmwf_grib(nwp_path_file3, preproc_dims, preproc_geoloc, &
+      if (verbose) write(*,*) 'Reading ecmwf path: ', trim(nwp_fnames%nwp_path_file3(idx))
+      call read_ecmwf_grib(nwp_fnames%nwp_path_file3(idx), preproc_dims, preproc_geoloc, &
            preproc_prtm, verbose)
    end select
 

--- a/pre_processing/read_ecmwf_nc.F90
+++ b/pre_processing/read_ecmwf_nc.F90
@@ -17,7 +17,7 @@
 ! Arguments:
 ! Name            Type In/Out/Both Description
 ! ------------------------------------------------------------------------------
-! ecmwf_path     string  In   NetCDF ECMWF file to be opened.
+! nwp_path     string  In   NetCDF ECMWF file to be opened.
 ! ecmwf          struct  both Structure summarising contents of ECMWF files.
 ! preproc_dims   struct  In   Dimensions of the preprocessing grid.
 ! preproc_prtm   struct  Both Pressure-level information for RTTOV.
@@ -75,8 +75,8 @@
 !   consistent across files for example the variable name could be lnsp or LNSP
 !-------------------------------------------------------------------------------
 
-subroutine read_ecmwf_nc(ecmwf_path, ecmwf, preproc_dims, preproc_geoloc, &
-     preproc_prtm, verbose, ecmwf_flag)
+subroutine read_ecmwf_nc(nwp_path, ecmwf, preproc_dims, preproc_geoloc, &
+     preproc_prtm, verbose, nwp_flag)
 
    use orac_ncdf_m
    use preproc_constants_m
@@ -84,13 +84,13 @@ subroutine read_ecmwf_nc(ecmwf_path, ecmwf, preproc_dims, preproc_geoloc, &
 
    implicit none
 
-   character(len=*),        intent(in)    :: ecmwf_path
+   character(len=*),        intent(in)    :: nwp_path
    type(ecmwf_t),           intent(in)    :: ecmwf
    type(preproc_dims_t),    intent(in)    :: preproc_dims
    type(preproc_geoloc_t),  intent(in)    :: preproc_geoloc
    type(preproc_prtm_t),    intent(inout) :: preproc_prtm
    logical,                 intent(in)    :: verbose
-   integer,                 intent(in)    :: ecmwf_flag
+   integer,                 intent(in)    :: nwp_flag
 
    integer(lint),     external            :: INTIN, INTOUT, INTF
    integer(lint),     parameter           :: BUFFER = 2000000
@@ -148,7 +148,7 @@ subroutine read_ecmwf_nc(ecmwf_path, ecmwf, preproc_dims, preproc_geoloc, &
    nj = ceiling((area(1)+90.)/grid(2)) - floor((area(3)+90.)/grid(2)) + 1
 
    ! open file
-   call ncdf_open(fid, ecmwf_path, 'read_ecmwf_nc()')
+   call ncdf_open(fid, nwp_path, 'read_ecmwf_nc()')
    if (nf90_inquire(fid, nVariables=nvar) .ne. 0) &
         call h_e_e('nc', 'NF INQ failed.')
 
@@ -240,14 +240,14 @@ subroutine read_ecmwf_nc(ecmwf_path, ecmwf, preproc_dims, preproc_geoloc, &
       if (nf90_inquire_variable(fid, ivar, name) .ne. 0) &
            call h_e_e('nc', 'NF VAR INQUIRE failed.')
       if (three_d) then
-         if (ecmwf_flag.ne.4 .and. ecmwf_flag .ne. 5) then
+         if (nwp_flag.ne.4 .and. nwp_flag .ne. 5) then
             call ncdf_read_array(fid, name, dummy3d)
          else
             call ncdf_read_array(fid, name, dummy3d_2)
          end if
          do k = 1, ecmwf%kdim
             old_len = n
-            if (ecmwf_flag.ne.4 .and. ecmwf_flag .ne. 5) then
+            if (nwp_flag.ne.4 .and. nwp_flag .ne. 5) then
                old_data(1:n) = reshape(real(dummy3d(:,:,k,1), kind=8), [n])
             else
                old_data(1:n) = reshape(real(dummy3d_2(:,:,k), kind=8), [n])

--- a/pre_processing/read_ecmwf_wind_badc.F90
+++ b/pre_processing/read_ecmwf_wind_badc.F90
@@ -16,7 +16,7 @@
 ! Arguments:
 ! Name       Type   In/Out/Both Description
 ! ------------------------------------------------------------------------------
-! ecmwf_path string in   Full path to a ECMWF NCDF file to read.
+! nwp_path string in   Full path to a ECMWF NCDF file to read.
 ! ecmwf2path string in   "
 ! ecmwf3path string in   "
 ! ecmwf      struct both Structure summarising contents of ECMWF files.
@@ -29,20 +29,20 @@
 ! 2016/02/02, OS: Now reads into HR ERA structure if flag is set.
 ! 2016/04/04, SP: Add option to process ECMWF forecast in single NetCDF4 file
 !    Note: This should work with either the OPER or FCST streams from ECMWF.
-! 2016/04/26, AP: Moved refences to ecmwf_flag and high_res up a level.
+! 2016/04/26, AP: Moved refences to nwp_flag and high_res up a level.
 !
 ! Bugs:
 ! None known.
 !-------------------------------------------------------------------------------
 
-subroutine read_ecmwf_wind_badc(ecmwf_path, ecmwf2path, ecmwf3path, ecmwf)
+subroutine read_ecmwf_wind_badc(nwp_path, ecmwf2path, ecmwf3path, ecmwf)
 
    use grib_api
    use preproc_constants_m
 
    implicit none
 
-   character(len=*), intent(in)    :: ecmwf_path
+   character(len=*), intent(in)    :: nwp_path
    character(len=*), intent(in)    :: ecmwf2path, ecmwf3path
    type(ecmwf_t),    intent(inout) :: ecmwf
 
@@ -62,7 +62,7 @@ subroutine read_ecmwf_wind_badc(ecmwf_path, ecmwf2path, ecmwf3path, ecmwf)
    call ecmwf_wind_init(ecmwf)
 
    ! ggas NCDF file, giving U10,V10,lat,lon
-   call read_ecmwf_wind_nc_file(ecmwf_path,ecmwf)
+   call read_ecmwf_wind_nc_file(nwp_path,ecmwf)
 
    ! loop over GRIB files for vertical coordinate
    do i=1,2

--- a/pre_processing/read_ecmwf_wind_grib.F90
+++ b/pre_processing/read_ecmwf_wind_grib.F90
@@ -17,7 +17,7 @@
 ! Arguments:
 ! Name       Type   In/Out/Both Description
 ! ------------------------------------------------------------------------------
-! ecmwf_path string in   Full path to ECMWF NCDF file to read.
+! nwp_path string in   Full path to ECMWF NCDF file to read.
 ! ecmwf      struct both Structure summarising contents of ECMWF files.
 !
 ! History:
@@ -31,23 +31,23 @@
 ! 2016/05/26, GT: Moved ecmwf%kdim=nk statement inside if (.not. high_res) block,
 !    as nk is undefined in the high_res case
 ! 2017/02/07, SP: Added support for NOAA GFS atmosphere data (ExtWork)
-! 2017/04/11, SP: Added ecmwf_flag=6, for working with GFS analysis files.
+! 2017/04/11, SP: Added nwp_flag=6, for working with GFS analysis files.
 !
 ! Bugs:
 ! None known.
 !-------------------------------------------------------------------------------
 
-subroutine read_ecmwf_wind_grib(ecmwf_path, ecmwf, high_res, ecmwf_flag)
+subroutine read_ecmwf_wind_grib(nwp_path, ecmwf, high_res, nwp_flag)
 
    use grib_api
    use preproc_constants_m
 
    implicit none
 
-   character(len=*), intent(in)    :: ecmwf_path
+   character(len=*), intent(in)    :: nwp_path
    type(ecmwf_t),    intent(inout) :: ecmwf
    logical,          intent(in)    :: high_res
-   integer,          intent(in)    :: ecmwf_flag
+   integer,          intent(in)    :: nwp_flag
 
    real, allocatable, dimension(:) :: pv, lat, lon, val
    integer                         :: fid, gid, stat
@@ -56,20 +56,20 @@ subroutine read_ecmwf_wind_grib(ecmwf_path, ecmwf, high_res, ecmwf_flag)
    integer                         :: param, level, nlevels
    character(len=100)              :: ltype, lname
 
-   if (len_trim(ecmwf_path) .gt. 1024) call h_e_e('wind_grib', &
-         'Filename argument string ecmwf_path is too long.  It must be ' // &
+   if (len_trim(nwp_path) .gt. 1024) call h_e_e('wind_grib', &
+         'Filename argument string nwp_path is too long.  It must be ' // &
          'limited to a length of 1024 due to a bug in grib_api.')
 
    ! open file
-   call grib_open_file(fid, trim(ecmwf_path), 'r', stat)
+   call grib_open_file(fid, trim(nwp_path), 'r', stat)
    if (stat .ne. 0) call h_e_e('wind_grib', 'Error opening GRIB file. '// &
-        trim(ecmwf_path))
+        trim(nwp_path))
    call grib_new_from_file(fid, gid, stat)
    if (stat .ne. 0) call h_e_e('wind_grib', 'Error getting GRIB_ID. '// &
-        trim(ecmwf_path))
+        trim(nwp_path))
    if (gid .eq. GRIB_END_OF_FILE) call h_e_e('wind_grib', 'Empty GRIB file.')
 
-   if ((.not. high_res) .and. (ecmwf_flag .ne. 6 .and. ecmwf_flag .ne. 7 .and. ecmwf_flag .ne. 8)) then
+   if ((.not. high_res) .and. (nwp_flag .ne. 6 .and. nwp_flag .ne. 7 .and. nwp_flag .ne. 8)) then
       ! ensure it contains the expected fields
       call grib_get(gid, 'PVPresent', PVPresent)
       if (stat .ne. 0) call h_e_e('wind_grib', 'Error getting PVPresent.')
@@ -107,7 +107,7 @@ subroutine read_ecmwf_wind_grib(ecmwf_path, ecmwf, high_res, ecmwf_flag)
    allocate(ecmwf%lat(nj))
 
    if (.not. high_res) then
-      if (ecmwf_flag .le. 5 .or. ecmwf_flag .gt. 8) then
+      if (nwp_flag .le. 5 .or. nwp_flag .gt. 8) then
          allocate(ecmwf%avec(nk+1))
          allocate(ecmwf%bvec(nk+1))
       else
@@ -194,7 +194,7 @@ subroutine read_ecmwf_wind_grib(ecmwf_path, ecmwf, high_res, ecmwf_flag)
          where (ecmwf%snow_depth .eq. 9999.) ecmwf%snow_depth = sreal_fill_value
       case(130)
          if (trim(ltype) .eq. 'surface') then
-            if (ecmwf_flag .eq. 6 .or. ecmwf_flag .eq. 7  .or. ecmwf_flag .eq. 8) then
+            if (nwp_flag .eq. 6 .or. nwp_flag .eq. 7  .or. nwp_flag .eq. 8) then
                ! skin temp (GFS) - proxied by surface temp
                call grib_get_data(gid, lat, lon, val, stat)
                if (stat .ne. 0) call h_e_e('wind_grib', &
@@ -223,7 +223,7 @@ subroutine read_ecmwf_wind_grib(ecmwf_path, ecmwf, high_res, ecmwf_flag)
 
    ecmwf%xdim = ni
    ecmwf%ydim = nj
-   if (.not. high_res .and. (ecmwf_flag .le. 5 .or. ecmwf_flag .gt. 8)) then
+   if (.not. high_res .and. (nwp_flag .le. 5 .or. nwp_flag .gt. 8)) then
       ecmwf%kdim = nk
       if (nk .ne. nlevels) &
            call h_e_e('wind_grib', 'Inconsistent vertical levels.')
@@ -232,7 +232,7 @@ subroutine read_ecmwf_wind_grib(ecmwf_path, ecmwf, high_res, ecmwf_flag)
    end if
 
    ! clean-up
-   if (.not. high_res .and. (ecmwf_flag .le. 5 .or. ecmwf_flag .gt. 8)) then
+   if (.not. high_res .and. (nwp_flag .le. 5 .or. nwp_flag .gt. 8)) then
       deallocate(pv)
    end if
    deallocate(lat)

--- a/pre_processing/read_ecmwf_wind_nc.F90
+++ b/pre_processing/read_ecmwf_wind_nc.F90
@@ -13,7 +13,7 @@
 ! Arguments:
 ! Name       Type   In/Out/Both Description
 ! ------------------------------------------------------------------------------
-! ecmwf_path string in   Full path to a ECMWF NCDF file to read.
+! nwp_path string in   Full path to a ECMWF NCDF file to read.
 ! ecmwf2path string in   "
 ! ecmwf3path string in   "
 ! ecmwf      struct both Structure summarising contents of ECMWF files.
@@ -36,20 +36,20 @@
 ! None known.
 !-------------------------------------------------------------------------------
 
-subroutine read_ecmwf_wind_nc(ecmwf, ecmwf_path, ecmwf_flag, ecmwf2path, ecmwf3path)
+subroutine read_ecmwf_wind_nc(ecmwf, nwp_path, nwp_flag, ecmwf2path, ecmwf3path)
 
    use preproc_constants_m
 
    implicit none
 
    type(ecmwf_t),    intent(inout)        :: ecmwf
-   character(len=*), intent(in)           :: ecmwf_path
-   integer,          intent(in)           :: ecmwf_flag
+   character(len=*), intent(in)           :: nwp_path
+   integer,          intent(in)           :: nwp_flag
    character(len=*), intent(in), optional :: ecmwf2path
    character(len=*), intent(in), optional :: ecmwf3path
 
    call ecmwf_wind_init(ecmwf)
-   if (ecmwf_flag .le. 5 .or. ecmwf_flag .gt. 8) then
+   if (nwp_flag .le. 5 .or. nwp_flag .gt. 8) then
       call ecmwf_abvec_init(ecmwf)
    else
       allocate(ecmwf%avec(ecmwf%kdim))
@@ -57,7 +57,7 @@ subroutine read_ecmwf_wind_nc(ecmwf, ecmwf_path, ecmwf_flag, ecmwf2path, ecmwf3p
    end if
 
    ! loop over given files (order not necessarily known)
-   call read_ecmwf_wind_nc_file(ecmwf_path, ecmwf)
+   call read_ecmwf_wind_nc_file(nwp_path, ecmwf)
    if (present(ecmwf2path)) call read_ecmwf_wind_nc_file(ecmwf2path, ecmwf)
    if (present(ecmwf3path)) call read_ecmwf_wind_nc_file(ecmwf3path, ecmwf)
 
@@ -82,7 +82,7 @@ end subroutine read_ecmwf_wind_nc
 ! Arguments:
 ! Name       Type   In/Out/Both Description
 ! ------------------------------------------------------------------------------
-! ecmwf_path string in   Full path to a ECMWF NCDF file to read.
+! nwp_path string in   Full path to a ECMWF NCDF file to read.
 ! ecmwf      struct both Structure summarising contents of ECMWF files.
 !
 ! History:
@@ -95,14 +95,14 @@ end subroutine read_ecmwf_wind_nc
 ! None known.
 !-------------------------------------------------------------------------------
 
-subroutine read_ecmwf_wind_nc_file(ecmwf_path, ecmwf)
+subroutine read_ecmwf_wind_nc_file(nwp_path, ecmwf)
 
    use orac_ncdf_m
    use preproc_constants_m
 
    implicit none
 
-   character(len=*), intent(in)    :: ecmwf_path
+   character(len=*), intent(in)    :: nwp_path
    type(ecmwf_t),    intent(inout) :: ecmwf
 
    real, allocatable               :: val(:,:,:,:)
@@ -110,7 +110,7 @@ subroutine read_ecmwf_wind_nc_file(ecmwf_path, ecmwf)
    character(len=var_length)       :: name
 
    ! open file
-   call ncdf_open(fid, ecmwf_path, 'read_ecmwf_wind_nc_file()')
+   call ncdf_open(fid, nwp_path, 'read_ecmwf_wind_nc_file()')
 
    ! check field dimensions for consistency
    if (nf90_inquire(fid, ndim, nvar) .ne. 0) &

--- a/pre_processing/read_ecmwf_wind_nc.F90
+++ b/pre_processing/read_ecmwf_wind_nc.F90
@@ -161,7 +161,7 @@ subroutine read_ecmwf_wind_nc_file(nwp_path, ecmwf)
             allocate(ecmwf%lat(ecmwf%ydim))
             call ncdf_read_array(fid, name, ecmwf%lat)
          end if
-      case('U10', 'U10M')
+      case('U10', 'U10M', 'u10')
          if (.not.associated(ecmwf%u10)) then
             allocate(ecmwf%u10(ecmwf%xdim,ecmwf%ydim))
             allocate(val(ecmwf%xdim,ecmwf%ydim,1,1))
@@ -169,7 +169,7 @@ subroutine read_ecmwf_wind_nc_file(nwp_path, ecmwf)
             ecmwf%u10 = val(:,:,1,1)
             deallocate(val)
          end if
-      case('V10', 'V10M')
+      case('V10', 'V10M', 'v10')
          if (.not.associated(ecmwf%v10)) then
             allocate(ecmwf%v10(ecmwf%xdim,ecmwf%ydim))
             allocate(val(ecmwf%xdim,ecmwf%ydim,1,1))
@@ -177,7 +177,7 @@ subroutine read_ecmwf_wind_nc_file(nwp_path, ecmwf)
             ecmwf%v10 = val(:,:,1,1)
             deallocate(val)
          end if
-      case('SKT')
+      case('SKT', 'skt')
          if (.not.associated(ecmwf%skin_temp)) then
             allocate(ecmwf%skin_temp(ecmwf%xdim,ecmwf%ydim))
             allocate(val(ecmwf%xdim,ecmwf%ydim,1,1))
@@ -193,7 +193,7 @@ subroutine read_ecmwf_wind_nc_file(nwp_path, ecmwf)
             ecmwf%snow_depth = val(:,:,1,1)
             deallocate(val)
          end if
-      case('CI', 'ci')
+      case('CI', 'ci', 'siconc')
          if (.not.associated(ecmwf%sea_ice_cover)) then
             allocate(ecmwf%sea_ice_cover(ecmwf%xdim,ecmwf%ydim))
             allocate(val(ecmwf%xdim,ecmwf%ydim,1,1))

--- a/pre_processing/read_era5_jasmin.F90
+++ b/pre_processing/read_era5_jasmin.F90
@@ -1,0 +1,253 @@
+!-------------------------------------------------------------------------------
+! Name: read_era5_jasmin.F90
+!
+! Purpose:
+! Deals with reading data from the JASMIN ERA5 archive, which has each variable
+! in a separate file. Therefore, we have to construct a lot of filenames first
+! (see: determine_jasmin_filenames_era5) before we can read the data.
+!
+!-------------------------------------------------------------------------------
+
+subroutine read_era5_jasmin(nwp_path, ecmwf, preproc_dims, preproc_geoloc, &
+     preproc_prtm, verbose, nwp_flag)
+
+   use orac_ncdf_m
+   use preproc_constants_m
+   use preproc_structures_m
+
+   implicit none
+
+   character(len=*),        intent(in)    :: nwp_path
+   type(ecmwf_t),           intent(in)    :: ecmwf
+   type(preproc_dims_t),    intent(in)    :: preproc_dims
+   type(preproc_geoloc_t),  intent(in)    :: preproc_geoloc
+   type(preproc_prtm_t),    intent(inout) :: preproc_prtm
+   logical,                 intent(in)    :: verbose
+   integer,                 intent(in)    :: nwp_flag
+
+   integer(lint),     external            :: INTIN, INTOUT, INTF
+   integer(lint),     parameter           :: BUFFER = 2000000
+
+   integer(lint),            dimension(1) :: intv, old_grib, new_grib
+   real(dreal)                            :: grid(2), area(4)
+   real(dreal), allocatable, dimension(:) :: old_data, new_data
+   character(len=20),        dimension(1) :: charv
+
+   real(sreal),       pointer             :: array2d(:,:), array3d(:,:,:)
+   integer(4)                             :: n, ni, nj, i, j, k, ivar
+   integer(4)                             :: fid, nvar
+   integer(4)                             :: old_len, new_len
+   character(len=20)                      :: name
+   logical                                :: three_d
+   real(sreal)   :: dummy2d(ecmwf%xdim,ecmwf%ydim,1,1)
+   real(sreal)   :: dummy3d(ecmwf%xdim,ecmwf%ydim,ecmwf%kdim,1)
+   real(sreal)   :: dummy3d_2(ecmwf%xdim,ecmwf%ydim,ecmwf%kdim)
+#ifdef WRAPPER
+   real(sreal)   :: ecmwf_lon(ecmwf%xdim)
+   real(sreal)   :: ecmwf_lat(ecmwf%ydim)
+   integer(lint) :: pointer_x(preproc_dims%min_lon:preproc_dims%max_lon)
+   integer(lint) :: pointer_y(preproc_dims%min_lat:preproc_dims%max_lat)
+   real(sreal)   :: diff_lon(ecmwf%xdim), diff_lat(ecmwf%ydim)
+#endif
+
+
+
+   n = ecmwf%xdim*ecmwf%ydim
+
+   ! input details of new grid (see note in read_ecmwf_grib)
+   charv(1) = 'yes'
+   grid(1) = sreal_fill_value
+   if (INTIN('missingvalue', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTIN missingvalue failed.')
+   charv(1) = 'unpacked'
+   if (INTIN('form', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTIN form failed.')
+   if (INTOUT('form', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTOUT form failed.')
+   intv(1) = ecmwf%ydim/2
+   if (INTIN('regular', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTIN reg failed.')
+   grid(1) = 0.5 / preproc_dims%dellon
+   grid(2) = 0.5 / preproc_dims%dellat
+   if (INTOUT('grid', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTOUT grid failed.')
+   area(1) = preproc_geoloc%latitude(preproc_dims%max_lat) + 0.01*grid(2)
+   area(2) = preproc_geoloc%longitude(preproc_dims%min_lon) + 0.01*grid(1)
+   area(3) = preproc_geoloc%latitude(preproc_dims%min_lat) + 0.01*grid(2)
+   area(4) = preproc_geoloc%longitude(preproc_dims%max_lon) + 0.01*grid(1)
+   if (INTOUT('area', intv, area, charv) .ne. 0) &
+        call h_e_e('nc', 'INTOUT area failed.')
+   ni = ceiling((area(4)+180.)/grid(1)) - floor((area(2)+180.)/grid(1)) + 1
+   nj = ceiling((area(1)+90.)/grid(2)) - floor((area(3)+90.)/grid(2)) + 1
+
+   ! open file
+   call ncdf_open(fid, nwp_path, 'read_era5_jasmin()')
+   if (nf90_inquire(fid, nVariables=nvar) .ne. 0) &
+        call h_e_e('nc', 'NF INQ failed.')
+
+   allocate(old_data(BUFFER))
+   allocate(new_data(BUFFER))
+
+   ! loop over variables
+   do ivar = 1, nvar
+
+      ! determine nearest ecmwf neighbour of preproc pixel
+#ifdef WRAPPER
+      if(ivar .eq. 1) then
+
+        call ncdf_read_array(fid, 'lon', ecmwf_lon)
+        call ncdf_read_array(fid, 'lat', ecmwf_lat)
+
+        where(ecmwf_lon .gt. 180.) ecmwf_lon = ecmwf_lon-360.
+
+        do i = preproc_dims%min_lon, preproc_dims%max_lon
+          diff_lon = abs(ecmwf_lon - preproc_geoloc%longitude(i))
+          pointer_x(i) = minloc(diff_lon, 1)
+        end do
+
+        do j = preproc_dims%min_lat, preproc_dims%max_lat
+          diff_lat = abs(ecmwf_lat - preproc_geoloc%latitude(j))
+          pointer_y(j) = minloc(diff_lat, 1)
+        end do
+
+      end if
+#endif
+
+      ! determine if field should be read
+      if (nf90_inquire_variable(fid, ivar, name) .ne. 0) &
+           call h_e_e('nc', 'NF VAR INQUIRE failed.')
+      select case (name)
+      case('Z', 'z')
+         three_d = .false.
+         array2d => preproc_prtm%geopot
+      case('Q', 'q')
+         three_d = .true.
+         array3d => preproc_prtm%spec_hum
+      case('T')
+         three_d = .true.
+         array3d => preproc_prtm%temperature
+      case('O3', 'o3')
+         three_d = .true.
+         array3d => preproc_prtm%ozone
+      case('LNSP', 'lnsp')
+         three_d = .false.
+         array2d => preproc_prtm%lnsp
+      case('CI', 'ci')
+         three_d = .false.
+         array2d => preproc_prtm%sea_ice_cover
+      case('ASN', 'asn')
+         three_d = .false.
+         array2d => preproc_prtm%snow_albedo
+      case('TCWV', 'tcwv')
+         three_d = .false.
+         array2d => preproc_prtm%totcolwv
+      case('SD', 'sd')
+         three_d = .false.
+         array2d => preproc_prtm%snow_depth
+      case('U10', 'u10', 'U10M')
+         three_d = .false.
+         array2d => preproc_prtm%u10
+      case('V10', 'v10', 'V10M')
+         three_d = .false.
+         array2d => preproc_prtm%v10
+      case('T2', 't2', 'T2M')
+         three_d = .false.
+         array2d => preproc_prtm%temp2
+      case('SKT', 'skt')
+         three_d = .false.
+         array2d => preproc_prtm%skin_temp
+      case('SSTK', 'sstk')
+         three_d = .false.
+         array2d => preproc_prtm%sst
+      case('AL', 'al', 'LSM')
+         three_d = .false.
+         array2d => preproc_prtm%land_sea_mask
+#ifdef INCLUDE_SATWX
+      case('cape', 'CAPE')
+         three_d = .false.
+         array2d => preproc_prtm%cape
+#endif
+      case default
+         cycle
+      end select
+      if (nf90_inquire_variable(fid, ivar, name) .ne. 0) &
+           call h_e_e('nc', 'NF VAR INQUIRE failed.')
+      if (three_d) then
+         if (nwp_flag.ne.4 .and. nwp_flag .ne. 5) then
+            call ncdf_read_array(fid, name, dummy3d)
+         else
+            call ncdf_read_array(fid, name, dummy3d_2)
+         end if
+         do k = 1, ecmwf%kdim
+            old_len = n
+            if (nwp_flag.ne.4 .and. nwp_flag .ne. 5) then
+               old_data(1:n) = reshape(real(dummy3d(:,:,k,1), kind=8), [n])
+            else
+               old_data(1:n) = reshape(real(dummy3d_2(:,:,k), kind=8), [n])
+            end if
+
+            new_len = BUFFER
+
+#ifndef WRAPPER
+            if (INTF(old_grib, old_len, old_data, new_grib, new_len, new_data).ne.0)&
+                  call h_e_e('nc', 'INTF failed.')
+            if (new_len .ne. ni*nj) print*, '3D Interpolation grid wrong.'
+
+            ! copy data into preprocessing grid
+            do j = 1, nj, 2
+               do i = 1, ni, 2
+                  array3d(preproc_dims%min_lon+i/2, &
+                     preproc_dims%min_lat+(nj-j)/2, k) = &
+                     real(new_data(i+(j-1)*ni), kind=4)
+               end do
+            end do
+#else
+            ! copy data into preprocessing grid
+            do i = preproc_dims%min_lon, preproc_dims%max_lon
+               do j = preproc_dims%min_lat, preproc_dims%max_lat
+                  array3d(i,j,k) = real(dummy3d(pointer_x(i), pointer_y(j), k, 1))
+               end do
+            end do
+#endif
+         end do
+         if (verbose) print*, trim(name), ') Min: ', minval(array3d), &
+              ', Max: ', maxval(array3d)
+      else
+         call ncdf_read_array(fid, name, dummy2d)
+         old_len = n
+         old_data(1:n) = reshape(real(dummy2d, kind=8), [n])
+
+         new_len = BUFFER
+
+#ifndef WRAPPER
+         if (INTF(old_grib, old_len, old_data, new_grib, new_len, new_data) .ne. 0) &
+               call h_e_e('nc', 'INTF failed.')
+         if (new_len .ne. ni*nj) print*, '2D Interpolation grid wrong.'
+
+         ! copy data into preprocessing grid
+         do j = 1, nj, 2
+            do i = 1, ni, 2
+               array2d(preproc_dims%min_lon+i/2, &
+                  preproc_dims%min_lat+(nj-j)/2) = &
+                  real(new_data(i+(j-1)*ni), kind=4)
+            end do
+         end do
+#else
+         ! copy data into preprocessing grid
+         do i = preproc_dims%min_lon, preproc_dims%max_lon
+            do j = preproc_dims%min_lat, preproc_dims%max_lat
+               array2d(i,j) = real(dummy2d(pointer_x(i), pointer_y(j), 1, 1))
+            end do
+         end do
+#endif
+         if (verbose) print*, trim(name), ') Min: ', minval(array2d), &
+              ', Max: ', maxval(array2d)
+      end if
+   end do
+
+   deallocate(old_data)
+   deallocate(new_data)
+
+   call ncdf_close(fid, 'read_era5_jasmin()')
+
+end subroutine read_era5_jasmin

--- a/pre_processing/read_era5_jasmin.F90
+++ b/pre_processing/read_era5_jasmin.F90
@@ -8,246 +8,339 @@
 !
 !-------------------------------------------------------------------------------
 
-subroutine read_era5_jasmin(nwp_path, ecmwf, preproc_dims, preproc_geoloc, &
-     preproc_prtm, verbose, nwp_flag)
+subroutine read_era5_jasmin_wind_nc(ecmwf, nwp_fnames, idx, nwp_flag)
 
-   use orac_ncdf_m
    use preproc_constants_m
-   use preproc_structures_m
+   use preproc_structures_m, only: preproc_nwp_fnames_t
 
    implicit none
 
-   character(len=*),        intent(in)    :: nwp_path
-   type(ecmwf_t),           intent(in)    :: ecmwf
-   type(preproc_dims_t),    intent(in)    :: preproc_dims
-   type(preproc_geoloc_t),  intent(in)    :: preproc_geoloc
-   type(preproc_prtm_t),    intent(inout) :: preproc_prtm
-   logical,                 intent(in)    :: verbose
-   integer,                 intent(in)    :: nwp_flag
+   type(ecmwf_t),    intent(inout)        :: ecmwf
+   type(preproc_nwp_fnames_t), intent(in) :: nwp_fnames
+   integer,          intent(in)           :: idx
+   integer,          intent(in)           :: nwp_flag
 
-   integer(lint),     external            :: INTIN, INTOUT, INTF
-   integer(lint),     parameter           :: BUFFER = 2000000
+   call ecmwf_wind_init(ecmwf)
+   call ecmwf_abvec_init(ecmwf)
 
-   integer(lint),            dimension(1) :: intv, old_grib, new_grib
-   real(dreal)                            :: grid(2), area(4)
-   real(dreal), allocatable, dimension(:) :: old_data, new_data
-   character(len=20),        dimension(1) :: charv
+   ! loop over given files
+   call read_ecmwf_wind_nc_file(nwp_fnames%ci_f(idx), ecmwf)
+   call read_ecmwf_wind_nc_file(nwp_fnames%u10_f(idx), ecmwf)
+   call read_ecmwf_wind_nc_file(nwp_fnames%v10_f(idx), ecmwf)
+   call read_ecmwf_wind_nc_file(nwp_fnames%skt_f(idx), ecmwf)
+   call read_ecmwf_wind_nc_file(nwp_fnames%sd_f(idx), ecmwf)
 
-   real(sreal),       pointer             :: array2d(:,:), array3d(:,:,:)
-   integer(4)                             :: n, ni, nj, i, j, k, ivar
-   integer(4)                             :: fid, nvar
-   integer(4)                             :: old_len, new_len
-   character(len=20)                      :: name
-   logical                                :: three_d
-   real(sreal)   :: dummy2d(ecmwf%xdim,ecmwf%ydim,1,1)
-   real(sreal)   :: dummy3d(ecmwf%xdim,ecmwf%ydim,ecmwf%kdim,1)
-   real(sreal)   :: dummy3d_2(ecmwf%xdim,ecmwf%ydim,ecmwf%kdim)
-#ifdef WRAPPER
-   real(sreal)   :: ecmwf_lon(ecmwf%xdim)
-   real(sreal)   :: ecmwf_lat(ecmwf%ydim)
-   integer(lint) :: pointer_x(preproc_dims%min_lon:preproc_dims%max_lon)
-   integer(lint) :: pointer_y(preproc_dims%min_lat:preproc_dims%max_lat)
-   real(sreal)   :: diff_lon(ecmwf%xdim), diff_lat(ecmwf%ydim)
-#endif
+end subroutine read_era5_jasmin_wind_nc
 
 
+subroutine read_era5_jasmin_nc(nwp_fnames, idx, ecmwf, preproc_dims, preproc_geoloc, &
+     preproc_prtm, verbose, nwp_flag)
 
-   n = ecmwf%xdim*ecmwf%ydim
+    use orac_ncdf_m
+    use preproc_constants_m
+    use preproc_structures_m
 
-   ! input details of new grid (see note in read_ecmwf_grib)
-   charv(1) = 'yes'
-   grid(1) = sreal_fill_value
-   if (INTIN('missingvalue', intv, grid, charv) .ne. 0) &
-        call h_e_e('nc', 'INTIN missingvalue failed.')
-   charv(1) = 'unpacked'
-   if (INTIN('form', intv, grid, charv) .ne. 0) &
-        call h_e_e('nc', 'INTIN form failed.')
-   if (INTOUT('form', intv, grid, charv) .ne. 0) &
-        call h_e_e('nc', 'INTOUT form failed.')
-   intv(1) = ecmwf%ydim/2
-   if (INTIN('regular', intv, grid, charv) .ne. 0) &
-        call h_e_e('nc', 'INTIN reg failed.')
-   grid(1) = 0.5 / preproc_dims%dellon
-   grid(2) = 0.5 / preproc_dims%dellat
-   if (INTOUT('grid', intv, grid, charv) .ne. 0) &
-        call h_e_e('nc', 'INTOUT grid failed.')
-   area(1) = preproc_geoloc%latitude(preproc_dims%max_lat) + 0.01*grid(2)
-   area(2) = preproc_geoloc%longitude(preproc_dims%min_lon) + 0.01*grid(1)
-   area(3) = preproc_geoloc%latitude(preproc_dims%min_lat) + 0.01*grid(2)
-   area(4) = preproc_geoloc%longitude(preproc_dims%max_lon) + 0.01*grid(1)
-   if (INTOUT('area', intv, area, charv) .ne. 0) &
-        call h_e_e('nc', 'INTOUT area failed.')
-   ni = ceiling((area(4)+180.)/grid(1)) - floor((area(2)+180.)/grid(1)) + 1
-   nj = ceiling((area(1)+90.)/grid(2)) - floor((area(3)+90.)/grid(2)) + 1
+    implicit none
 
-   ! open file
-   call ncdf_open(fid, nwp_path, 'read_era5_jasmin()')
-   if (nf90_inquire(fid, nVariables=nvar) .ne. 0) &
-        call h_e_e('nc', 'NF INQ failed.')
+    type(preproc_nwp_fnames_t), intent(in)    :: nwp_fnames
+    integer,                    intent(in)    :: idx
+    type(ecmwf_t),              intent(in)    :: ecmwf
+    type(preproc_dims_t),       intent(in)    :: preproc_dims
+    type(preproc_geoloc_t),     intent(in)    :: preproc_geoloc
+    type(preproc_prtm_t),       intent(inout) :: preproc_prtm
+    logical,                    intent(in)    :: verbose
+    integer,                    intent(in)    :: nwp_flag
 
-   allocate(old_data(BUFFER))
-   allocate(new_data(BUFFER))
+    integer(lint),     external            :: INTIN, INTOUT, INTF
+    integer(lint),     parameter           :: BUFFER = 2000000
 
-   ! loop over variables
-   do ivar = 1, nvar
+    integer(lint),            dimension(1) :: intv, old_grib, new_grib
+    real(dreal)                            :: grid(2), area(4)
+    character(len=20),        dimension(1) :: charv
 
-      ! determine nearest ecmwf neighbour of preproc pixel
-#ifdef WRAPPER
-      if(ivar .eq. 1) then
+    real(sreal),       pointer             :: array2d(:,:), array3d(:,:,:)
+    integer(4)                             :: n, ni, nj, i, j, k, ivar
+    integer(4)                             :: fid, nvar
+    integer(4)                             :: old_len, new_len
+    character(len=20)                      :: name
+    logical                                :: three_d
+    real(sreal)   :: dummy2d(ecmwf%xdim,ecmwf%ydim)
+    real(sreal)   :: dummy3d(ecmwf%xdim,ecmwf%ydim,ecmwf%kdim,1)
+    real(sreal)   :: dummy3d_2(ecmwf%xdim,ecmwf%ydim,ecmwf%kdim)
 
-        call ncdf_read_array(fid, 'lon', ecmwf_lon)
-        call ncdf_read_array(fid, 'lat', ecmwf_lat)
-
-        where(ecmwf_lon .gt. 180.) ecmwf_lon = ecmwf_lon-360.
-
-        do i = preproc_dims%min_lon, preproc_dims%max_lon
-          diff_lon = abs(ecmwf_lon - preproc_geoloc%longitude(i))
-          pointer_x(i) = minloc(diff_lon, 1)
-        end do
-
-        do j = preproc_dims%min_lat, preproc_dims%max_lat
-          diff_lat = abs(ecmwf_lat - preproc_geoloc%latitude(j))
-          pointer_y(j) = minloc(diff_lat, 1)
-        end do
-
-      end if
-#endif
-
-      ! determine if field should be read
-      if (nf90_inquire_variable(fid, ivar, name) .ne. 0) &
-           call h_e_e('nc', 'NF VAR INQUIRE failed.')
-      select case (name)
-      case('Z', 'z')
-         three_d = .false.
-         array2d => preproc_prtm%geopot
-      case('Q', 'q')
-         three_d = .true.
-         array3d => preproc_prtm%spec_hum
-      case('T')
-         three_d = .true.
-         array3d => preproc_prtm%temperature
-      case('O3', 'o3')
-         three_d = .true.
-         array3d => preproc_prtm%ozone
-      case('LNSP', 'lnsp')
-         three_d = .false.
-         array2d => preproc_prtm%lnsp
-      case('CI', 'ci')
-         three_d = .false.
-         array2d => preproc_prtm%sea_ice_cover
-      case('ASN', 'asn')
-         three_d = .false.
-         array2d => preproc_prtm%snow_albedo
-      case('TCWV', 'tcwv')
-         three_d = .false.
-         array2d => preproc_prtm%totcolwv
-      case('SD', 'sd')
-         three_d = .false.
-         array2d => preproc_prtm%snow_depth
-      case('U10', 'u10', 'U10M')
-         three_d = .false.
-         array2d => preproc_prtm%u10
-      case('V10', 'v10', 'V10M')
-         three_d = .false.
-         array2d => preproc_prtm%v10
-      case('T2', 't2', 'T2M')
-         three_d = .false.
-         array2d => preproc_prtm%temp2
-      case('SKT', 'skt')
-         three_d = .false.
-         array2d => preproc_prtm%skin_temp
-      case('SSTK', 'sstk')
-         three_d = .false.
-         array2d => preproc_prtm%sst
-      case('AL', 'al', 'LSM')
-         three_d = .false.
-         array2d => preproc_prtm%land_sea_mask
+    ! open file
+    ! Do temperature on model levels
+    array3d => preproc_prtm%temperature
+    call ncdf_open(fid, nwp_fnames%t_f(idx), 'read_era5_jasmin_nc_t()')
+    call ncdf_read_array(fid, 't', dummy3d_2)
+    call preproc_3d_var(dummy3d_2, ecmwf, preproc_dims, preproc_geoloc, array3d)
+    if (verbose) print*, 'T)     Min: ', minval(array3d), ', Max: ', maxval(array3d)
+    call ncdf_close(fid, 'read_era5_jasmin_t()')
+    
+    ! Do specific humidity on model levels
+    array3d => preproc_prtm%spec_hum
+    call ncdf_open(fid, nwp_fnames%q_f(idx), 'read_era5_jasmin_nc_q()')
+    call ncdf_read_array(fid, 'q', dummy3d_2)
+    call preproc_3d_var(dummy3d_2, ecmwf, preproc_dims, preproc_geoloc, array3d)
+    if (verbose) print*, 'Q)     Min: ', minval(array3d), ', Max: ', maxval(array3d)
+    call ncdf_close(fid, 'read_era5_jasmin_q()')
+    
+    ! Do ozone on model levels
+    array3d => preproc_prtm%ozone
+    call ncdf_open(fid, nwp_fnames%o3_f(idx), 'read_era5_jasmin_nc_o3()')
+    call ncdf_read_array(fid, 'o3', dummy3d_2)
+    call preproc_3d_var(dummy3d_2, ecmwf, preproc_dims, preproc_geoloc, array3d)
+    if (verbose) print*, 'O3)    Min: ', minval(array3d), ', Max: ', maxval(array3d)
+    call ncdf_close(fid, 'read_era5_jasmin_o3()')
+    
+    ! Do logarithm of surface pressure
+    array2d => preproc_prtm%lnsp
+    call ncdf_open(fid, nwp_fnames%lnsp_f(idx), 'read_era5_jasmin_nc_lnsp()')
+    call ncdf_read_array(fid, 'lnsp', dummy2d)
+    call preproc_2d_var(dummy2d, ecmwf, preproc_dims, preproc_geoloc, array2d)
+    if (verbose) print*, 'LNSP)  Min: ', minval(array2d), ', Max: ', maxval(array2d)
+    call ncdf_close(fid, 'read_era5_jasmin_lnsp()')
+    
+    ! Do geopotential
+    array2d => preproc_prtm%geopot
+    call ncdf_open(fid, nwp_fnames%z_f(idx), 'read_era5_jasmin_nc_z()')
+    call ncdf_read_array(fid, 'z', dummy2d)
+    call preproc_2d_var(dummy2d, ecmwf, preproc_dims, preproc_geoloc, array2d)
+    if (verbose) print*, 'GEOP)  Min: ', minval(array2d), ', Max: ', maxval(array2d)
+    call ncdf_close(fid, 'read_era5_jasmin_z()')
+    
+    ! Do sea ice fraction
+    array2d => preproc_prtm%sea_ice_cover
+    call ncdf_open(fid, nwp_fnames%ci_f(idx), 'read_era5_jasmin_nc()')
+    call ncdf_read_array(fid, 'siconc', dummy2d)
+    call preproc_2d_var(dummy2d, ecmwf, preproc_dims, preproc_geoloc, array2d)
+    if (verbose) print*, 'CI)    Min: ', minval(array2d), ', Max: ', maxval(array2d)
+    call ncdf_close(fid, 'read_era5_jasmin()')
+    
+    ! Do snow albedo
+    array2d => preproc_prtm%snow_albedo
+    call ncdf_open(fid, nwp_fnames%asn_f(idx), 'read_era5_jasmin_nc_asn()')
+    call ncdf_read_array(fid, 'asn', dummy2d)
+    call preproc_2d_var(dummy2d, ecmwf, preproc_dims, preproc_geoloc, array2d)
+    if (verbose) print*, 'ASN)   Min: ', minval(array2d), ', Max: ', maxval(array2d)
+    call ncdf_close(fid, 'read_era5_jasmin_asn()')
+    
+    ! Do total column water vapour
+    array2d => preproc_prtm%totcolwv
+    call ncdf_open(fid, nwp_fnames%tcwv_f(idx), 'read_era5_jasmin_nc_tcwv()')
+    call ncdf_read_array(fid, 'tcwv', dummy2d)
+    call preproc_2d_var(dummy2d, ecmwf, preproc_dims, preproc_geoloc, array2d)
+    if (verbose) print*, 'TCWV)  Min: ', minval(array2d), ', Max: ', maxval(array2d)
+    call ncdf_close(fid, 'read_era5_jasmin_tcwv()')
+    
+    ! Do snow depth
+    array2d => preproc_prtm%snow_depth
+    call ncdf_open(fid, nwp_fnames%sd_f(idx), 'read_era5_jasmin_nc_sd()')
+    call ncdf_read_array(fid, 'sd', dummy2d)
+    call preproc_2d_var(dummy2d, ecmwf, preproc_dims, preproc_geoloc, array2d)
+    if (verbose) print*, 'SD)    Min: ', minval(array2d), ', Max: ', maxval(array2d)
+    call ncdf_close(fid, 'read_era5_jasmin_sd()')
+    
+    ! Do U-component of 10m wind
+    array2d => preproc_prtm%u10
+    call ncdf_open(fid, nwp_fnames%u10_f(idx), 'read_era5_jasmin_nc_10u()')
+    call ncdf_read_array(fid, 'u10', dummy2d)
+    call preproc_2d_var(dummy2d, ecmwf, preproc_dims, preproc_geoloc, array2d)
+    if (verbose) print*, 'U10)    Min: ', minval(array2d), ', Max: ', maxval(array2d)
+    call ncdf_close(fid, 'read_era5_jasmin_nc_10u()')
+    
+    ! Do V-component of 10m wind
+    array2d => preproc_prtm%v10
+    call ncdf_open(fid, nwp_fnames%v10_f(idx), 'read_era5_jasmin_nc_10v()')
+    call ncdf_read_array(fid, 'v10', dummy2d)
+    call preproc_2d_var(dummy2d, ecmwf, preproc_dims, preproc_geoloc, array2d)
+    if (verbose) print*, 'V10)    Min: ', minval(array2d), ', Max: ', maxval(array2d)
+    call ncdf_close(fid, 'read_era5_jasmin_nc_10v()')
+    
+    ! Do 2m temperature
+    array2d => preproc_prtm%temp2
+    call ncdf_open(fid, nwp_fnames%t2_f(idx), 'read_era5_jasmin_nc_t2()')
+    call ncdf_read_array(fid, 't2m', dummy2d)
+    call preproc_2d_var(dummy2d, ecmwf, preproc_dims, preproc_geoloc, array2d)
+    if (verbose) print*, 'T2)     Min: ', minval(array2d), ', Max: ', maxval(array2d)
+    call ncdf_close(fid, 'read_era5_jasmin_nc_t2()')
+    
+    ! Do skin temperature
+    array2d => preproc_prtm%skin_temp
+    call ncdf_open(fid, nwp_fnames%skt_f(idx), 'read_era5_jasmin_nc_skt()')
+    call ncdf_read_array(fid, 'skt', dummy2d)
+    call preproc_2d_var(dummy2d, ecmwf, preproc_dims, preproc_geoloc, array2d)
+    if (verbose) print*, 'SKT)     Min: ', minval(array2d), ', Max: ', maxval(array2d)
+    call ncdf_close(fid, 'read_era5_jasmin_nc_skt()')
+    
+    ! Do sea surface temperature
+    array2d => preproc_prtm%sst
+    call ncdf_open(fid, nwp_fnames%sstk_f(idx), 'read_era5_jasmin_nc_sst()')
+    call ncdf_read_array(fid, 'sst', dummy2d)
+    call preproc_2d_var(dummy2d, ecmwf, preproc_dims, preproc_geoloc, array2d)
+    if (verbose) print*, 'SST)     Min: ', minval(array2d), ', Max: ', maxval(array2d)
+    call ncdf_close(fid, 'read_era5_jasmin_nc_sst()')
+    
 #ifdef INCLUDE_SATWX
-      case('cape', 'CAPE')
-         three_d = .false.
-         array2d => preproc_prtm%cape
+    ! Do convective available potential energy
+    array2d => preproc_prtm%cape
+    call ncdf_open(fid, nwp_fnames%cape_f(idx), 'read_era5_jasmin_nc_cape()')
+    call ncdf_read_array(fid, 'cape', dummy2d)
+    call preproc_2d_var(dummy2d, ecmwf, preproc_dims, preproc_geoloc, array2d)
+    if (verbose) print*, 'CAPE)    Min: ', minval(array2d), ', Max: ', maxval(array2d)
+    call ncdf_close(fid, 'read_era5_jasmin_nc_cape()')
 #endif
-      case default
-         cycle
-      end select
-      if (nf90_inquire_variable(fid, ivar, name) .ne. 0) &
-           call h_e_e('nc', 'NF VAR INQUIRE failed.')
-      if (three_d) then
-         if (nwp_flag.ne.4 .and. nwp_flag .ne. 5) then
-            call ncdf_read_array(fid, name, dummy3d)
-         else
-            call ncdf_read_array(fid, name, dummy3d_2)
-         end if
-         do k = 1, ecmwf%kdim
-            old_len = n
-            if (nwp_flag.ne.4 .and. nwp_flag .ne. 5) then
-               old_data(1:n) = reshape(real(dummy3d(:,:,k,1), kind=8), [n])
-            else
-               old_data(1:n) = reshape(real(dummy3d_2(:,:,k), kind=8), [n])
-            end if
+end subroutine read_era5_jasmin_nc
 
-            new_len = BUFFER
+subroutine preproc_3d_var(dummy_in, ecmwf, preproc_dims, preproc_geoloc, out_arr3d)
 
-#ifndef WRAPPER
-            if (INTF(old_grib, old_len, old_data, new_grib, new_len, new_data).ne.0)&
-                  call h_e_e('nc', 'INTF failed.')
-            if (new_len .ne. ni*nj) print*, '3D Interpolation grid wrong.'
+    use preproc_constants_m
+    use preproc_structures_m
 
-            ! copy data into preprocessing grid
-            do j = 1, nj, 2
-               do i = 1, ni, 2
-                  array3d(preproc_dims%min_lon+i/2, &
-                     preproc_dims%min_lat+(nj-j)/2, k) = &
-                     real(new_data(i+(j-1)*ni), kind=4)
-               end do
+    real(sreal), dimension(:,:,:), intent(in)    :: dummy_in
+    type(ecmwf_t),                 intent(in)    :: ecmwf
+    type(preproc_dims_t),          intent(in)    :: preproc_dims
+    type(preproc_geoloc_t),        intent(in)    :: preproc_geoloc
+    real(sreal), pointer,          intent(inout) :: out_arr3d(:,:, :)
+
+    integer(lint),     dimension(1)        :: intv, old_grib, new_grib
+    integer(lint),     external            :: INTIN, INTOUT, INTF
+    integer(lint),     parameter           :: BUFFER = 2000000
+    character(len=20), dimension(1)        :: charv
+    real(dreal)                            :: grid(2), area(4)
+    real(dreal), allocatable, dimension(:) :: old_data, new_data
+
+    integer(4)                             :: n, ni, nj, i, j, k, ivar
+    integer(4)                             :: old_len, new_len
+
+    n = ecmwf%xdim*ecmwf%ydim
+
+    ! input details of new grid (see note in read_ecmwf_grib)
+    charv(1) = 'yes'
+    grid(1) = sreal_fill_value
+    if (INTIN('missingvalue', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTIN missingvalue failed.')
+    charv(1) = 'unpacked'
+    if (INTIN('form', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTIN form failed.')
+    if (INTOUT('form', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTOUT form failed.')
+    intv(1) = ecmwf%ydim/2
+    if (INTIN('regular', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTIN reg failed.')
+    grid(1) = 0.5 / preproc_dims%dellon
+    grid(2) = 0.5 / preproc_dims%dellat
+    if (INTOUT('grid', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTOUT grid failed.')
+    area(1) = preproc_geoloc%latitude(preproc_dims%max_lat) + 0.01*grid(2)
+    area(2) = preproc_geoloc%longitude(preproc_dims%min_lon) + 0.01*grid(1)
+    area(3) = preproc_geoloc%latitude(preproc_dims%min_lat) + 0.01*grid(2)
+    area(4) = preproc_geoloc%longitude(preproc_dims%max_lon) + 0.01*grid(1)
+    if (INTOUT('area', intv, area, charv) .ne. 0) &
+        call h_e_e('nc', 'INTOUT area failed.')
+        
+    ni = ceiling((area(4)+180.)/grid(1)) - floor((area(2)+180.)/grid(1)) + 1
+    nj = ceiling((area(1)+90.)/grid(2)) - floor((area(3)+90.)/grid(2)) + 1
+
+    allocate(old_data(BUFFER))
+    allocate(new_data(BUFFER))
+   
+    do k = 1, ecmwf%kdim
+        old_len = n
+        old_data(1:n) = reshape(real(dummy_in(:,:,k), kind=8), [n])
+
+        new_len = BUFFER
+
+        if (INTF(old_grib, old_len, old_data, new_grib, new_len, new_data).ne.0)&
+            call h_e_e('nc', 'INTF failed.')
+        
+        if (new_len .ne. ni*nj) print*, '3D Interpolation grid wrong, '
+
+        ! copy data into preprocessing grid
+        do j = 1, nj, 2
+            do i = 1, ni, 2
+                out_arr3d(preproc_dims%min_lon+i/2, preproc_dims%min_lat+(nj-j)/2, k) = real(new_data(i+(j-1)*ni), kind=4)
             end do
-#else
-            ! copy data into preprocessing grid
-            do i = preproc_dims%min_lon, preproc_dims%max_lon
-               do j = preproc_dims%min_lat, preproc_dims%max_lat
-                  array3d(i,j,k) = real(dummy3d(pointer_x(i), pointer_y(j), k, 1))
-               end do
-            end do
-#endif
-         end do
-         if (verbose) print*, trim(name), ') Min: ', minval(array3d), &
-              ', Max: ', maxval(array3d)
-      else
-         call ncdf_read_array(fid, name, dummy2d)
-         old_len = n
-         old_data(1:n) = reshape(real(dummy2d, kind=8), [n])
+        end do
+    end do   
 
-         new_len = BUFFER
+    deallocate(old_data)
+    deallocate(new_data)
 
-#ifndef WRAPPER
-         if (INTF(old_grib, old_len, old_data, new_grib, new_len, new_data) .ne. 0) &
-               call h_e_e('nc', 'INTF failed.')
-         if (new_len .ne. ni*nj) print*, '2D Interpolation grid wrong.'
+end subroutine preproc_3d_var
 
-         ! copy data into preprocessing grid
+
+subroutine preproc_2d_var(dummy_in, ecmwf, preproc_dims, preproc_geoloc, out_arr2d)
+
+    use preproc_constants_m
+    use preproc_structures_m
+
+    real(sreal), dimension(:,:),   intent(in)    :: dummy_in
+    type(ecmwf_t),                 intent(in)    :: ecmwf
+    type(preproc_dims_t),          intent(in)    :: preproc_dims
+    type(preproc_geoloc_t),        intent(in)    :: preproc_geoloc
+    real(sreal), pointer,          intent(inout) :: out_arr2d(:,:)
+
+    integer(lint),     dimension(1)        :: intv, old_grib, new_grib
+    integer(lint),     external            :: INTIN, INTOUT, INTF
+    integer(lint),     parameter           :: BUFFER = 2000000
+    character(len=20), dimension(1)        :: charv
+    real(dreal)                            :: grid(2), area(4)
+    real(dreal), allocatable, dimension(:) :: old_data, new_data
+
+    integer(4)                             :: n, ni, nj, i, j, ivar
+    integer(4)                             :: old_len, new_len
+
+    n = ecmwf%xdim*ecmwf%ydim
+
+    ! input details of new grid (see note in read_ecmwf_grib)
+    charv(1) = 'yes'
+    grid(1) = sreal_fill_value
+    if (INTIN('missingvalue', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTIN missingvalue failed.')
+    charv(1) = 'unpacked'
+    if (INTIN('form', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTIN form failed.')
+    if (INTOUT('form', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTOUT form failed.')
+    intv(1) = ecmwf%ydim/2
+    if (INTIN('regular', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTIN reg failed.')
+    grid(1) = 0.5 / preproc_dims%dellon
+    grid(2) = 0.5 / preproc_dims%dellat
+    if (INTOUT('grid', intv, grid, charv) .ne. 0) &
+        call h_e_e('nc', 'INTOUT grid failed.')
+    area(1) = preproc_geoloc%latitude(preproc_dims%max_lat) + 0.01*grid(2)
+    area(2) = preproc_geoloc%longitude(preproc_dims%min_lon) + 0.01*grid(1)
+    area(3) = preproc_geoloc%latitude(preproc_dims%min_lat) + 0.01*grid(2)
+    area(4) = preproc_geoloc%longitude(preproc_dims%max_lon) + 0.01*grid(1)
+    if (INTOUT('area', intv, area, charv) .ne. 0) &
+        call h_e_e('nc', 'INTOUT area failed.')
+        
+    ni = ceiling((area(4)+180.)/grid(1)) - floor((area(2)+180.)/grid(1)) + 1
+    nj = ceiling((area(1)+90.)/grid(2)) - floor((area(3)+90.)/grid(2)) + 1
+
+    allocate(old_data(BUFFER))
+    allocate(new_data(BUFFER))
+
+    old_len = n
+    old_data(1:n) = reshape(real(dummy_in(:,:), kind=8), [n])
+
+    new_len = BUFFER
+
+    if (INTF(old_grib, old_len, old_data, new_grib, new_len, new_data).ne.0)&
+        call h_e_e('nc', 'INTF failed.')
+    
+    if (new_len .ne. ni*nj) print*, '2D Interpolation grid wrong, '
+
+    ! copy data into preprocessing grid
          do j = 1, nj, 2
             do i = 1, ni, 2
-               array2d(preproc_dims%min_lon+i/2, &
-                  preproc_dims%min_lat+(nj-j)/2) = &
-                  real(new_data(i+(j-1)*ni), kind=4)
+               out_arr2d(preproc_dims%min_lon+i/2, preproc_dims%min_lat+(nj-j)/2) = real(new_data(i+(j-1)*ni), kind=4)
             end do
          end do
-#else
-         ! copy data into preprocessing grid
-         do i = preproc_dims%min_lon, preproc_dims%max_lon
-            do j = preproc_dims%min_lat, preproc_dims%max_lat
-               array2d(i,j) = real(dummy2d(pointer_x(i), pointer_y(j), 1, 1))
-            end do
-         end do
-#endif
-         if (verbose) print*, trim(name), ') Min: ', minval(array2d), &
-              ', Max: ', maxval(array2d)
-      end if
-   end do
 
-   deallocate(old_data)
-   deallocate(new_data)
+    deallocate(old_data)
+    deallocate(new_data)
 
-   call ncdf_close(fid, 'read_era5_jasmin()')
-
-end subroutine read_era5_jasmin
+end subroutine preproc_2d_var

--- a/pre_processing/read_gfs_nc.F90
+++ b/pre_processing/read_gfs_nc.F90
@@ -17,7 +17,7 @@
 ! Arguments:
 ! Name            Type In/Out/Both Description
 ! ------------------------------------------------------------------------------
-! ecmwf_path     string  In   NetCDF ECMWF file to be opened.
+! nwp_path     string  In   NetCDF ECMWF file to be opened.
 ! ecmwf          struct  both Structure summarising contents of ECMWF files.
 ! preproc_dims   struct  In   Dimensions of the preprocessing grid.
 ! preproc_prtm   struct  Both Pressure-level information for RTTOV.
@@ -31,8 +31,8 @@
 !   consistent across files for example the variable name could be lnsp or LNSP
 !-------------------------------------------------------------------------------
 
-subroutine read_gfs_nc(ecmwf_path, ecmwf, preproc_dims, preproc_geoloc, &
-     preproc_prtm, verbose, ecmwf_flag)
+subroutine read_gfs_nc(nwp_path, ecmwf, preproc_dims, preproc_geoloc, &
+     preproc_prtm, verbose, nwp_flag)
 
    use orac_ncdf_m
    use preproc_constants_m
@@ -40,13 +40,13 @@ subroutine read_gfs_nc(ecmwf_path, ecmwf, preproc_dims, preproc_geoloc, &
 
    implicit none
 
-   character(len=*),        intent(in)    :: ecmwf_path
+   character(len=*),        intent(in)    :: nwp_path
    type(ecmwf_t),           intent(in)    :: ecmwf
    type(preproc_dims_t),    intent(in)    :: preproc_dims
    type(preproc_geoloc_t),  intent(in)    :: preproc_geoloc
    type(preproc_prtm_t),    intent(inout) :: preproc_prtm
    logical,                 intent(in)    :: verbose
-   integer,                 intent(in)    :: ecmwf_flag
+   integer,                 intent(in)    :: nwp_flag
 
    integer(lint),     external            :: INTIN, INTOUT, INTF
    integer(lint),     parameter           :: BUFFER = 3000000
@@ -103,7 +103,7 @@ subroutine read_gfs_nc(ecmwf_path, ecmwf, preproc_dims, preproc_geoloc, &
    nj = ceiling((area(1)+90.)/grid(2)) - floor((area(3)+90.)/grid(2)) + 1
 
    ! open file
-   call ncdf_open(fid, ecmwf_path, 'read_gfs_nc()')
+   call ncdf_open(fid, nwp_path, 'read_gfs_nc()')
    if (nf90_inquire(fid, nVariables=nvar) .ne. 0) &
         call h_e_e('nc', 'NF INQ failed.')
 

--- a/pre_processing/rearrange_ecmwf.F90
+++ b/pre_processing/rearrange_ecmwf.F90
@@ -31,12 +31,11 @@
 ! None known.
 !-------------------------------------------------------------------------------
 
-subroutine rearrange_ecmwf(ecmwf,highRes)
+subroutine rearrange_ecmwf(ecmwf)
 
    implicit none
 
    type(ecmwf_t), intent(inout) :: ecmwf
-   logical,       intent(in)    :: highRes
 
    integer                      :: date, ind, i
    real(kind=sreal), allocatable, dimension(:,:) :: u, v
@@ -52,16 +51,14 @@ subroutine rearrange_ecmwf(ecmwf,highRes)
    ind = ecmwf%xdim + 1 - date
 
    ! Swap the left and right halfs into a temp array
-   if (.not. highRes) then
-      ! Wind fields are not contained in high resolution data
-      allocate(u(ecmwf%xdim,ecmwf%ydim))
-      u(1:ind,:)  = ecmwf%u10(date:,:)
-      u(ind+1:,:) = ecmwf%u10(1:date-1,:)
-
-      allocate(v(ecmwf%xdim,ecmwf%ydim))
-      v(1:ind,:)  = ecmwf%v10(date:,:)
-      v(ind+1:,:) = ecmwf%v10(1:date-1,:)
-   end if
+   ! Wind fields are not contained in high resolution data
+   allocate(u(ecmwf%xdim,ecmwf%ydim))
+   u(1:ind,:)  = ecmwf%u10(date:,:)
+   u(ind+1:,:) = ecmwf%u10(1:date-1,:)
+ 
+   allocate(v(ecmwf%xdim,ecmwf%ydim))
+   v(1:ind,:)  = ecmwf%v10(date:,:)
+   v(ind+1:,:) = ecmwf%v10(1:date-1,:)
 
    allocate(skint(ecmwf%xdim,ecmwf%ydim))
    skint(1:ind,:)  = ecmwf%skin_temp(date:,:)
@@ -84,10 +81,8 @@ subroutine rearrange_ecmwf(ecmwf,highRes)
 
    ! flip in the y direction from the temp to the original
    do i=1,ecmwf%ydim
-      if (.not. highRes) then
-         ecmwf%u10(:,ecmwf%ydim+1-i) = u(:,i)
-         ecmwf%v10(:,ecmwf%ydim+1-i) = v(:,i)
-      end if
+      ecmwf%u10(:,ecmwf%ydim+1-i) = u(:,i)
+      ecmwf%v10(:,ecmwf%ydim+1-i) = v(:,i)
       ecmwf%skin_temp(:,ecmwf%ydim+1-i)     = skint(:,i)
       ecmwf%snow_depth(:,ecmwf%ydim+1-i)    = snow_depth(:,i)
       ecmwf%sea_ice_cover(:,ecmwf%ydim+1-i) = sea_ice_cover(:,i)
@@ -97,10 +92,8 @@ subroutine rearrange_ecmwf(ecmwf,highRes)
    ecmwf%lon = lon
    ecmwf%lat = lat
 
-   if (.not. highRes) then
-      deallocate(u)
-      deallocate(v)
-   end if
+   deallocate(u)
+   deallocate(v)
    deallocate(skint)
    deallocate(snow_depth)
    deallocate(sea_ice_cover)

--- a/pre_processing/set_ecmwf.F90
+++ b/pre_processing/set_ecmwf.F90
@@ -361,8 +361,6 @@ subroutine determine_jasmin_filenames_era5(nwp_fnames, cyear, cmonth, cday, chou
     
     character(len=path_length)                :: ml_dir, sfc_dir
     
-    print*,cyear, ' ', cmonth, ' ', cday, ' ', chour
-    
     ml_dir = trim(adjustl(nwp_fnames%nwp_path(idx)))//'an_ml/'// &
              trim(adjustl(cyear))//'/'// &
              trim(adjustl(cmonth))//'/'// &
@@ -370,7 +368,7 @@ subroutine determine_jasmin_filenames_era5(nwp_fnames, cyear, cmonth, cday, chou
              trim(adjustl(cyear))// &
              trim(adjustl(cmonth))// &
              trim(adjustl(cday))// &
-             trim(adjustl(chour))//'.'
+             trim(adjustl(chour))//'00.'
              
     sfc_dir = trim(adjustl(nwp_fnames%nwp_path(idx)))//'an_sfc/'// &
               trim(adjustl(cyear))//'/'// &
@@ -379,7 +377,7 @@ subroutine determine_jasmin_filenames_era5(nwp_fnames, cyear, cmonth, cday, chou
               trim(adjustl(cyear))// &
               trim(adjustl(cmonth))// &
               trim(adjustl(cday))// &
-              trim(adjustl(chour))//'.'
+              trim(adjustl(chour))//'00.'
     
     ! Set up surface variables   
     nwp_fnames%ci_f(idx) = trim(adjustl(sfc_dir))//'ci.nc'
@@ -400,30 +398,6 @@ subroutine determine_jasmin_filenames_era5(nwp_fnames, cyear, cmonth, cday, chou
     nwp_fnames%lnsp_f(idx) = trim(adjustl(ml_dir))//'lnsp.nc'
     nwp_fnames%u_f(idx) = trim(adjustl(ml_dir))//'u.nc'
     nwp_fnames%v_f(idx) = trim(adjustl(ml_dir))//'v.nc'
-    nwp_fnames%z_f(idx) = trim(adjustl(ml_dir))//'z.nc'
-    
-    print*, trim(nwp_fnames%ci_f(idx))
-    print*, trim(nwp_fnames%asn_f(idx))
-    print*, trim(nwp_fnames%tcwv_f(idx))
-    print*, trim(nwp_fnames%sd_f(idx))
-    print*, trim(nwp_fnames%u10_f(idx))
-    print*, trim(nwp_fnames%v10_f(idx))
-    print*, trim(nwp_fnames%t2_f(idx))
-    print*, trim(nwp_fnames%skt_f(idx))
-    print*, trim(nwp_fnames%sstk_f(idx))
-    print*, trim(nwp_fnames%cape_f(idx))
-      
-    ! Set up model level variables
-    print*, trim(nwp_fnames%q_f(idx))
-    print*, trim(nwp_fnames%t_f(idx))
-    print*, trim(nwp_fnames%o3_f(idx))
-    print*, trim(nwp_fnames%lnsp_f(idx))
-    print*, trim(nwp_fnames%u_f(idx))
-    print*, trim(nwp_fnames%v_f(idx))
-    print*, trim(nwp_fnames%z_f(idx))
-    
-    stop
-
-    
+    nwp_fnames%z_f(idx) = trim(adjustl(ml_dir))//'z.nc'    
    
 end subroutine determine_jasmin_filenames_era5

--- a/pre_processing/set_ecmwf.F90
+++ b/pre_processing/set_ecmwf.F90
@@ -66,18 +66,19 @@
 ! None known.
 !-------------------------------------------------------------------------------
 
-subroutine set_ecmwf(granule, opts, nwp_flag, imager_geolocation, &
+subroutine set_ecmwf(granule, opts, nwp_fnames, nwp_flag, imager_geolocation, &
    imager_time, time_int_fac, assume_full_path)
 
    use calender_m
    use imager_structures_m
    use preproc_constants_m
-   use preproc_structures_m, only: preproc_opts_t, setup_args_t
+   use preproc_structures_m, only: preproc_nwp_fnames_t, preproc_opts_t, setup_args_t
 
    implicit none
 
    type(setup_args_t),         intent(in)    :: granule
    type(preproc_opts_t),       intent(inout) :: opts
+   type(preproc_nwp_fnames_t), intent(inout) :: nwp_fnames
    integer,                    intent(in)    :: nwp_flag
    type(imager_geolocation_t), intent(in)    :: imager_geolocation
    type(imager_time_t),        intent(in)    :: imager_time
@@ -107,22 +108,22 @@ subroutine set_ecmwf(granule, opts, nwp_flag, imager_geolocation, &
 
    if (assume_full_path) then
       ! for nwp_flag=2, ensure NCDF file is listed in nwp_pathout
-      if (index(opts%nwp_path(1), '.nc') .gt. 0) then
-         opts%nwp_path_file  = opts%nwp_path
-         opts%nwp_path_file2 = opts%nwp_path2
-         opts%nwp_path_file3 = opts%nwp_path3
-      else if (index(opts%nwp_path2(1), '.nc') .gt. 0) then
-         opts%nwp_path_file  = opts%nwp_path2
-         opts%nwp_path_file2 = opts%nwp_path
-         opts%nwp_path_file3 = opts%nwp_path3
-      else if (index(opts%nwp_path3(1), '.nc') .gt. 0) then
-         opts%nwp_path_file  = opts%nwp_path3
-         opts%nwp_path_file2 = opts%nwp_path
-         opts%nwp_path_file3 = opts%nwp_path2
+      if (index(nwp_fnames%nwp_path(1), '.nc') .gt. 0) then
+         nwp_fnames%nwp_path_file  = nwp_fnames%nwp_path
+         nwp_fnames%nwp_path_file2 = nwp_fnames%nwp_path2
+         nwp_fnames%nwp_path_file3 = nwp_fnames%nwp_path3
+      else if (index(nwp_fnames%nwp_path2(1), '.nc') .gt. 0) then
+         nwp_fnames%nwp_path_file  = nwp_fnames%nwp_path2
+         nwp_fnames%nwp_path_file2 = nwp_fnames%nwp_path
+         nwp_fnames%nwp_path_file3 = nwp_fnames%nwp_path3
+      else if (index(nwp_fnames%nwp_path3(1), '.nc') .gt. 0) then
+         nwp_fnames%nwp_path_file  = nwp_fnames%nwp_path3
+         nwp_fnames%nwp_path_file2 = nwp_fnames%nwp_path
+         nwp_fnames%nwp_path_file3 = nwp_fnames%nwp_path2
       else
-         opts%nwp_path_file  = opts%nwp_path
-         opts%nwp_path_file2 = opts%nwp_path2
-         opts%nwp_path_file3 = opts%nwp_path3
+         nwp_fnames%nwp_path_file  = nwp_fnames%nwp_path
+         nwp_fnames%nwp_path_file2 = nwp_fnames%nwp_path2
+         nwp_fnames%nwp_path_file3 = nwp_fnames%nwp_path3
       end if
    else
       if (opts%ecmwf_time_int_method .eq. 0) then
@@ -143,9 +144,9 @@ subroutine set_ecmwf(granule, opts, nwp_flag, imager_geolocation, &
          i_path1 = 1
 
          call make_ecmwf_name(granule%cyear, granule%cmonth, granule%cday, &
-              cera_hour, nwp_flag, opts%nwp_path(1), opts%nwp_path2(1), &
-              opts%nwp_path3(1), opts%nwp_path_file(1), &
-              opts%nwp_path_file2(1), opts%nwp_path_file3(1))
+              cera_hour, nwp_flag, nwp_fnames%nwp_path(1), nwp_fnames%nwp_path2(1), &
+              nwp_fnames%nwp_path3(1), nwp_fnames%nwp_path_file(1), &
+              nwp_fnames%nwp_path_file2(1), nwp_fnames%nwp_path_file3(1))
       else if (opts%ecmwf_time_int_method .eq. 1) then
          ! Pick the closest ERA interim file wrt sensor time
          if (jday - jday0 .lt. jday1 - jday) then
@@ -175,9 +176,9 @@ subroutine set_ecmwf(granule, opts, nwp_flag, imager_geolocation, &
          end if
 
          call make_ecmwf_name(cera_year, cera_month, cera_day, cera_hour, &
-              nwp_flag, opts%nwp_path(i_path1), opts%nwp_path2(i_path1), &
-              opts%nwp_path3(i_path1), opts%nwp_path_file(1), &
-              opts%nwp_path_file2(1), opts%nwp_path_file3(1))
+              nwp_flag, nwp_fnames%nwp_path(i_path1), nwp_fnames%nwp_path2(i_path1), &
+              nwp_fnames%nwp_path3(i_path1), nwp_fnames%nwp_path_file(1), &
+              nwp_fnames%nwp_path_file2(1), nwp_fnames%nwp_path_file3(1))
       else if (opts%ecmwf_time_int_method .eq. 2) then
          ! Pick the ERA interim files before and after wrt sensor time
 
@@ -208,9 +209,9 @@ subroutine set_ecmwf(granule, opts, nwp_flag, imager_geolocation, &
          end if
 
          call make_ecmwf_name(cera_year, cera_month, cera_day, cera_hour, &
-              nwp_flag, opts%nwp_path(i_path1), opts%nwp_path2(i_path1), &
-              opts%nwp_path3(i_path1), opts%nwp_path_file(1), &
-              opts%nwp_path_file2(1), opts%nwp_path_file3(1))
+              nwp_flag, nwp_fnames%nwp_path(i_path1), nwp_fnames%nwp_path2(i_path1), &
+              nwp_fnames%nwp_path3(i_path1), nwp_fnames%nwp_path_file(1), &
+              nwp_fnames%nwp_path_file2(1), nwp_fnames%nwp_path_file3(1))
 
          ! now look at the next file
          day_before = day
@@ -235,9 +236,9 @@ subroutine set_ecmwf(granule, opts, nwp_flag, imager_geolocation, &
          end if
 
          call make_ecmwf_name(cera_year, cera_month, cera_day, cera_hour, &
-              nwp_flag, opts%nwp_path(i_path2), opts%nwp_path2(i_path2), &
-              opts%nwp_path3(i_path2), opts%nwp_path_file(2), &
-              opts%nwp_path_file2(2), opts%nwp_path_file3(2))
+              nwp_flag, nwp_fnames%nwp_path(i_path2), nwp_fnames%nwp_path2(i_path2), &
+              nwp_fnames%nwp_path3(i_path2), nwp_fnames%nwp_path_file(2), &
+              nwp_fnames%nwp_path_file2(2), nwp_fnames%nwp_path_file3(2))
       else
          write(*,*) 'ERROR: invalid set_ecmwf() time_interp_method: ', &
               opts%ecmwf_time_int_method

--- a/pre_processing/set_ecmwf.F90
+++ b/pre_processing/set_ecmwf.F90
@@ -254,32 +254,6 @@ subroutine set_ecmwf(granule, opts, ecmwf_flag, imager_geolocation, &
       end if
    end if
 
-   if (opts%ecmwf_path_hr(1) .eq. '') then
-      call build_ecmwf_HR_file_from_LR(opts%ecmwf_path_file(1), &
-              opts%ecmwf_hr_path_file(1))
-      if (opts%ecmwf_time_int_method .eq. 2) then
-         call build_ecmwf_HR_file_from_LR(opts%ecmwf_path_file(2), &
-              opts%ecmwf_hr_path_file(2))
-      end if
-   else if (assume_full_path) then
-      opts%ecmwf_hr_path_file(1) = opts%ecmwf_path_hr(1)
-      if (opts%ecmwf_time_int_method .eq. 2) &
-           opts%ecmwf_hr_path_file(2) = opts%ecmwf_path_hr(2)
-   else
-      if (opts%ecmwf_time_int_method .ne. 2) then
-         call build_ecmwf_HR_file_from_LR2(opts%ecmwf_path(i_path1), &
-              opts%ecmwf_path_file(1), opts%ecmwf_path_hr(1), &
-              opts%ecmwf_hr_path_file(1))
-      else
-         call build_ecmwf_HR_file_from_LR2(opts%ecmwf_path(i_path1), &
-              opts%ecmwf_path_file(1), opts%ecmwf_path_hr(1), &
-              opts%ecmwf_hr_path_file(1))
-         call build_ecmwf_HR_file_from_LR2(opts%ecmwf_path(i_path2), &
-              opts%ecmwf_path_file(2), opts%ecmwf_path_hr(1), &
-              opts%ecmwf_hr_path_file(2))
-      end if
-   end if
-
 end subroutine set_ecmwf
 
 #ifdef __PGI

--- a/pre_processing/utils_for_main.F90
+++ b/pre_processing/utils_for_main.F90
@@ -87,9 +87,6 @@ subroutine parse_optional(label, value, preproc_opts)
       end if
       if (parse_string(value, preproc_opts%channel_ids) /= 0) &
          call handle_parse_error(label)
-   case('USE_HR_ECMWF')
-      if (parse_string(value, preproc_opts%use_hr_ecmwf) /= 0) &
-         call handle_parse_error(label)
    case('ECMWF_TIME_INT_METHOD')
       if (parse_string(value, preproc_opts%ecmwf_time_int_method) /= 0) &
          call handle_parse_error(label)
@@ -107,12 +104,6 @@ subroutine parse_optional(label, value, preproc_opts)
          call handle_parse_error(label)
    case('ECMWF_PATH3_2')
       if (parse_string(value, preproc_opts%ecmwf_path3(2)) /= 0) &
-         call handle_parse_error(label)
-   case('ECMWF_PATH_HR')
-      if (parse_string(value, preproc_opts%ecmwf_path_hr(1)) /= 0) &
-         call handle_parse_error(label)
-   case('ECMWF_PATH_HR_2')
-      if (parse_string(value, preproc_opts%ecmwf_path_hr(2)) /= 0) &
          call handle_parse_error(label)
    case('ECMWF_NLEVELS')
       if (parse_string(value, preproc_opts%ecmwf_nlevels) /= 0) &

--- a/pre_processing/utils_for_main.F90
+++ b/pre_processing/utils_for_main.F90
@@ -8,9 +8,9 @@
 !    module produced interfaces.
 ! 2015/09/14, GM: Move handle_parse_error() to trunk/common/parsing.F90.
 ! 2015/10/19, GM: Add use_modis_emis_in_rttov to parse_optional().
-! 2015/11/26, GM: Add ecmwf_time_int_method, ecmwf_path_file, ecmwf_path_file2,
-!    and ecmwf_path_file3 to parse_optional().
-! 2016/02/02, CP: Add ecmwf_path_hr.
+! 2015/11/26, GM: Add ecmwf_time_int_method, nwp_path_file, nwp_path_file2,
+!    and nwp_path_file3 to parse_optional().
+! 2016/02/02, CP: Add nwp_path_hr.
 ! 2016/02/02, GM: Add use_hr_ecmwf.
 ! 2016/02/02, GM: Add use_ecmwf_snow_and_ice.
 ! 2016/04/05, SP: Added ECMWF_NLEVELS option to choose between 60,91 and 137
@@ -97,16 +97,16 @@ subroutine parse_optional(label, value, preproc_opts)
       if (parse_string(value, preproc_opts%use_modis_emis_in_rttov) /= 0) &
          call handle_parse_error(label)
    case('ECMWF_PATH_2')
-      if (parse_string(value, preproc_opts%ecmwf_path(2)) /= 0) &
+      if (parse_string(value, preproc_opts%nwp_path(2)) /= 0) &
          call handle_parse_error(label)
    case('ECMWF_PATH2_2')
-      if (parse_string(value, preproc_opts%ecmwf_path2(2)) /= 0) &
+      if (parse_string(value, preproc_opts%nwp_path2(2)) /= 0) &
          call handle_parse_error(label)
    case('ECMWF_PATH3_2')
-      if (parse_string(value, preproc_opts%ecmwf_path3(2)) /= 0) &
+      if (parse_string(value, preproc_opts%nwp_path3(2)) /= 0) &
          call handle_parse_error(label)
    case('ECMWF_NLEVELS')
-      if (parse_string(value, preproc_opts%ecmwf_nlevels) /= 0) &
+      if (parse_string(value, preproc_opts%nwp_nlevels) /= 0) &
          call handle_parse_error(label)
    case('USE_L1_LAND_MASK')
       if (parse_string(value, preproc_opts%use_l1_land_mask) /= 0) &
@@ -116,6 +116,9 @@ subroutine parse_optional(label, value, preproc_opts)
            call handle_parse_error(label)
    case('OCCCI_PATH')
       if (parse_string(value, preproc_opts%occci_path) /= 0) &
+           call handle_parse_error(label)
+   case('NWP_TIME_FACTOR')
+      if (parse_string(value, preproc_opts%nwp_time_factor) /= 0) &
            call handle_parse_error(label)
    case('USE_PREDEF_LSM')
       if (parse_string(value, preproc_opts%use_predef_lsm) /= 0) &

--- a/pre_processing/utils_for_main.F90
+++ b/pre_processing/utils_for_main.F90
@@ -62,7 +62,7 @@ subroutine parse_required(lun, value, name)
 end subroutine parse_required
 
 
-subroutine parse_optional(label, value, preproc_opts)
+subroutine parse_optional(label, value, preproc_opts, nwp_fnames)
 
    use parsing_m
    use preproc_constants_m
@@ -73,6 +73,7 @@ subroutine parse_optional(label, value, preproc_opts)
    character(len=*),     intent(in)    :: label
    character(len=*),     intent(in)    :: value
    type(preproc_opts_t), intent(inout) :: preproc_opts
+   type(preproc_nwp_fnames_t), intent(inout) :: nwp_fnames
 
 
    select case (label)
@@ -97,13 +98,13 @@ subroutine parse_optional(label, value, preproc_opts)
       if (parse_string(value, preproc_opts%use_modis_emis_in_rttov) /= 0) &
          call handle_parse_error(label)
    case('ECMWF_PATH_2')
-      if (parse_string(value, preproc_opts%nwp_path(2)) /= 0) &
+      if (parse_string(value, nwp_fnames%nwp_path(2)) /= 0) &
          call handle_parse_error(label)
    case('ECMWF_PATH2_2')
-      if (parse_string(value, preproc_opts%nwp_path2(2)) /= 0) &
+      if (parse_string(value, nwp_fnames%nwp_path2(2)) /= 0) &
          call handle_parse_error(label)
    case('ECMWF_PATH3_2')
-      if (parse_string(value, preproc_opts%nwp_path3(2)) /= 0) &
+      if (parse_string(value, nwp_fnames%nwp_path3(2)) /= 0) &
          call handle_parse_error(label)
    case('ECMWF_NLEVELS')
       if (parse_string(value, preproc_opts%nwp_nlevels) /= 0) &


### PR DESCRIPTION
This PR enables support for the ERA5 data on JASMIN, which comes in lots of separate files rather than one large netCDF4 file as currently supported by ORAC.
This PR also rearranges the `ecmwf_flag` options as described below: