### PR TITLE
Update SLSTR reader to overcome array bounds error.

### DIFF
--- a/pre_processing/read_slstr_funcs.F90
+++ b/pre_processing/read_slstr_funcs.F90
@@ -257,7 +257,7 @@ subroutine read_slstr_visdata(indir, inband, outarr, imager_angles, sx, sy, &
    call ncdf_close(fid, 'read_slstr_visdata()')
 
    ! Resample the data to the TIR grid size.
-   call slstr_resample_vis_to_tir(data1, outarr(offset:offset+nx-1,:), &
+   call slstr_resample_vis_to_tir(data1, outarr(offset+1:offset+nx,:), &
         nx, ny, sreal_fill_value)
 
    ! Convert from radiances to reflectances


### PR DESCRIPTION
The SLSTR reader currently reads outside the array bounds when resampling TIR data to VIS resolution:
```At line 263 of file read_slstr_funcs.F90
Fortran runtime error: Index '0' of dimension 1 of array 'outarr' outside of expected range (1:1500)
```

This fixes the issue by reading from `1:1500` instead of `0:1499`.