### PR TITLE
Set default LUT interpolation method to Bicubic rather than Linear.

### DIFF
--- a/src/read_driver.F90
+++ b/src/read_driver.F90
@@ -610,7 +610,10 @@ subroutine Read_Driver(Ctrl, global_atts, source_atts)
 
    !----------------------- Ctrl SWITCHES -----------------
    Ctrl%i_equation_form  = switch_cls(c, Default=3, AerOx=1, AerSw=0, AerBR=1)
-   Ctrl%LUTIntSelm       = switch_app(a, Default=LUTIntMethLinear)
+   ! Bicubic interpolation (LUTIntMethBicubic) is the default LUT
+   ! interpolation method in ORAC. For a faster but less accurate LUT
+   ! interpolation method you could use LUTIntMethLinear.
+   Ctrl%LUTIntSelm       = switch_app(a, Default=LUTIntMethBicubic)
    Ctrl%RTMIntSelm       = switch_app(a, Default=RTMIntMethLinear, Aer=RTMIntMethNone)
    Ctrl%CloudType        = switch_app(a, Default=1,                Aer=2)
    Ctrl%Max_SDAD         = 10.0


### PR DESCRIPTION
Based on discussions at the last ORAC meeting it is suggested that Bicubic interpolation be used by default in ORAC for Look-Up Table interpolation. I've suggested linear interpolation as a faster but less accurate option in the comments of read_driver.F90.