### PR TITLE
Add flag to force nighttime retrieval.

### DIFF
--- a/src/alloc_spixel.F90
+++ b/src/alloc_spixel.F90
@@ -164,8 +164,7 @@ subroutine Alloc_SPixel(Ctrl, RTM, SPixel)
    SPixel%Ind%NSolar = 0
    SPixel%Ind%NThermal = 0
    SPixel%Ind%NMixed = 0
-
-   allocate(SPixel%Illum(Ctrl%Ind%NViews))
+   SPixel%Illum = 0
 
    ! These are reallocated in GetMeasurements
    allocate(SPixel%Ym(1))

--- a/src/ctrl.F90
+++ b/src/ctrl.F90
@@ -300,6 +300,7 @@ module Ctrl_m
                                                    ! in an order of decreasing
                                                    ! priority.
       logical                :: do_new_night_retrieval
+      logical                :: force_nighttime_retrieval  ! Sets SPixel%Illum(:) = INight
       logical                :: do_CTX_correction
       real                   :: CTP_correction_limit
 

--- a/src/ctrl.F90
+++ b/src/ctrl.F90
@@ -300,7 +300,7 @@ module Ctrl_m
                                                    ! in an order of decreasing
                                                    ! priority.
       logical                :: do_new_night_retrieval
-      logical                :: force_nighttime_retrieval  ! Sets SPixel%Illum(:) = INight
+      logical                :: force_nighttime_retrieval  ! Sets SPixel%Illum = INight
       logical                :: do_CTX_correction
       real                   :: CTP_correction_limit
 

--- a/src/dealloc_spixel.F90
+++ b/src/dealloc_spixel.F90
@@ -116,7 +116,6 @@ subroutine Dealloc_SPixel(Ctrl, SPixel)
 
    ! Super-pixel active and inactive state vectors, measurements and errors.
 
-   deallocate(SPixel%illum)
    deallocate(SPixel%Ym)
    deallocate(SPixel%Sy)
    deallocate(SPixel%ViewIdx)

--- a/src/get_indexing.F90
+++ b/src/get_indexing.F90
@@ -112,36 +112,34 @@ subroutine Get_Indexing(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
    ! Initialise Approach and Class bits
    SPixel%variables_retrieved = (Ctrl%Approach-1) + 8*(Ctrl%Class-1)
 
-
-   ! If the views have different illumination conditions then skip this pixel
-   do i_view = 1, Ctrl%Ind%NViews
-      SPixel%illum(i_view) = MSI_Data%illum(SPixel%Loc%X0, SPixel%Loc%Y0, i_view)
-
-      if ((i_view > 1) .and. (.not. Ctrl%all_channels_same_view)) then
-         if (SPixel%illum(i_view - 1) /= SPixel%illum(i_view)) then
-            status = SPixelIndexing
-            return
-         end if
-      end if
-   end do
-
    ! Force nighttime retrieval
    if (Ctrl%force_nighttime_retrieval) then
-      SPixel%Illum(:) = INight
+      SPixel%Illum = INight
+   else
+      ! If the views have different illumination conditions then skip this pixel
+      do i_view = 1, Ctrl%Ind%NViews
+         SPixel%Illum = MSI_Data%illum(SPixel%Loc%X0, SPixel%Loc%Y0, i_view)
+         if ((i_view > 1) .and. (.not. Ctrl%all_channels_same_view)) then
+            if (MSI_Data%Illum(SPixel%Loc%X0, SPixel%Loc%Y0, i_view-1) /= SPixel%Illum) then
+               status = SPixelIndexing
+               return
+            end if
+         end if
+      end do
    end if
 
    ! Find which channels are either not used based on illumination conditions
    ! and/or are flagged as missing.
    is_not_used_or_missing = .false.
 
-   if (SPixel%Illum(1) .eq. IDay) then
+   if (Spixel%Illum .eq. IDay) then
       ! All channels are used
       do i_chan = 1, Ctrl%Ind%Ny
          if (MSI_Data%MSI(SPixel%Loc%X0, SPixel%Loc%Y0, i_chan) == sreal_fill_value) then
             is_not_used_or_missing(i_chan) = .true.
          end if
       end do
-   else if (SPixel%Illum(1) .eq. ITwi)  then
+   else if (Spixel%Illum .eq. ITwi)  then
       ! Only pure thermal channels (no mixed) are used
       do i_chan = 1, Ctrl%Ind%Ny
          if (btest(Ctrl%Ind%Ch_Is(i_chan), SolarBit) .or. &
@@ -149,7 +147,7 @@ subroutine Get_Indexing(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
             is_not_used_or_missing(i_chan) = .true.
          end if
       end do
-   else if (SPixel%Illum(1) .eq. INight) then
+   else if (Spixel%Illum .eq. INight) then
       ! All thermal channels (including mixed) are used
       do i_chan = 1, Ctrl%Ind%Ny
          if (.not. btest(Ctrl%Ind%Ch_Is(i_chan), ThermalBit) .or. &
@@ -166,7 +164,7 @@ subroutine Get_Indexing(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
    select case (Ctrl%Approach)
    case (AppCld1L)
       if (.not. Ctrl%do_new_night_retrieval &
-          .or. SPixel%Illum(1) .eq. IDay .or. SPixel%Illum(1) .eq. ITwi) then
+          .or. Spixel%Illum .eq. IDay .or. Spixel%Illum .eq. ITwi) then
          call cloud_indexing_logic(Ctrl, SPixel, is_not_used_or_missing, &
                                    X, XJ, XI, status)
       else
@@ -214,8 +212,8 @@ subroutine Get_Indexing(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
    end if
 
    ! Set the illumination-dependent first guess and a priori
-   SPixel%FG = Ctrl%FG(:,SPixel%Illum(1))
-   SPixel%AP = Ctrl%AP(:,SPixel%Illum(1))
+   SPixel%FG = Ctrl%FG(:,Spixel%Illum)
+   SPixel%AP = Ctrl%AP(:,Spixel%Illum)
 
    ! Set up all the channel indexes
    call setup_indexes(Ctrl, SAD_Chan, SPixel, is_not_used_or_missing)
@@ -269,13 +267,13 @@ subroutine setup_indexes(Ctrl, SAD_Chan, SPixel, is_not_used_or_missing)
          SPixel%Ind%Ny = SPixel%Ind%Ny + 1
 
          if (btest(Ctrl%Ind%Ch_Is(i), SolarBit) .and. &
-             SPixel%illum(1) .eq. IDay .and. &
+             Spixel%Illum .eq. IDay .and. &
              btest(Ctrl%Ind%Ch_Is(i), ThermalBit)) then
             SPixel%Ind%NMixed   = SPixel%Ind%NMixed + 1
          end if
 
          if (btest(Ctrl%Ind%Ch_Is(i), SolarBit) .and. &
-             SPixel%illum(1) .eq. IDay) then
+             Spixel%Illum .eq. IDay) then
             SPixel%Ind%NSolar   = SPixel%Ind%NSolar + 1
          end if
 
@@ -317,7 +315,7 @@ subroutine setup_indexes(Ctrl, SAD_Chan, SPixel, is_not_used_or_missing)
          cycle
 
       if (btest(Ctrl%Ind%Ch_Is(i), SolarBit) .and. &
-          SPixel%illum(1) .eq. IDay .and. &
+          Spixel%Illum .eq. IDay .and. &
           btest(Ctrl%Ind%Ch_Is(i), ThermalBit)) then
          ! Mixed channels out of those to be retrieved
          SPixel%Ind%YMixed(i2) = ii
@@ -327,7 +325,7 @@ subroutine setup_indexes(Ctrl, SAD_Chan, SPixel, is_not_used_or_missing)
       end if
 
       if (btest(Ctrl%Ind%Ch_Is(i), SolarBit) .and. &
-          SPixel%illum(1) .eq. IDay) then
+          Spixel%Illum .eq. IDay) then
          ! Solar channels out of those to be used
          SPixel%Ind%YSolar(i0) = ii
          SPixel%spixel_y_solar_to_ctrl_y_index(i0) = i
@@ -491,7 +489,7 @@ subroutine cloud_indexing_logic(Ctrl, SPixel, is_not_used_or_missing, &
    ! channels then pick the first one in Ctrl%ReChans that matches and set the
    ! rest of the Ctrl%ReChans that match to missing.  If Ctrl%ReChans is not
    ! associated it is assumed that all available r_e channels should be used.
-   if (SPixel%Illum(1) .eq. IDay .and. associated(Ctrl%ReChans)) then
+   if (Spixel%Illum .eq. IDay .and. associated(Ctrl%ReChans)) then
       i_r_e_chan = 0
       do i_chan = 1, size(Ctrl%ReChans)
          ii_chan = find_in_array(Ctrl%r_e_chans, Ctrl%ReChans(i_chan))
@@ -552,29 +550,29 @@ subroutine cloud_indexing_logic(Ctrl, SPixel, is_not_used_or_missing, &
    ii_xi = 0
    n_ir_chans2 = n_ir_chans
    ! Retrieve Tau if sufficient appropriate channels are available
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITau, X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, &
         active = n_tau_chans .ge. min_tau_chans)
    ! Retrieve Re if sufficient appropriate channels are available (if thermal
    ! channels used, decrement the IR channel counter)
    if (re_thermal) then
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IRe, X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe, X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, &
            active = n_r_e_chans .ge. min_r_e_chans, ch_available = n_ir_chans2)
    else
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IRe, X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe, X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, &
            active = n_r_e_chans .ge. min_r_e_chans)
    end if
    ! Pc, Ts, Fr retreved for all illumination. n_ir_chans2 ensures there aren't
    ! more things retrieved than there are measurements
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IPc, X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc, X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, &
         active = n_ir_chans2 .ge. min_ir_chans, ch_available = n_ir_chans2)
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITs, X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, ITs, X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, &
         active = n_ir_chans2 .ge. min_ir_chans, ch_available = n_ir_chans2)
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IFr, X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, IFr, X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, &
         active = n_ir_chans2 .ge. min_ir_chans, ch_available = n_ir_chans2)
 
@@ -584,7 +582,7 @@ subroutine cloud_indexing_logic(Ctrl, SPixel, is_not_used_or_missing, &
    else
       min_rho = MaxRho_XX
    end if
-   call Identify_BRDF_Terms(Ctrl, SPixel%Illum(1), 1, min_rho, &
+   call Identify_BRDF_Terms(Ctrl, Spixel%Illum, 1, min_rho, &
         is_not_used_or_missing, X, ii_x, XJ, ii_xj, XI, ii_xi, &
         SPixel%variables_retrieved, .false.)
 
@@ -655,44 +653,44 @@ subroutine cloud_indexing_logic_night(Ctrl, SPixel, is_not_used_or_missing, &
    ii_xi = 0
 
    if (n_chans .eq. 1) then
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITau, X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .false.)
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IRe,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .false.)
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IPc,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITs,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITs,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .false.)
    else if (n_chans .eq. 2) then
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITau, X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .false.)
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IRe,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .false.)
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IPc,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITs,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITs,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
    else if (n_chans .eq. 3) then
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITau, X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IRe,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IPc,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITs,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITs,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
    else if (n_chans .ge. 4) then
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITau, X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IRe,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IPc,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITs,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITs,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
    end if
 
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IFr,  X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, IFr,  X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .false.)
 
    ! Add BRDF terms to parameter vector
@@ -701,7 +699,7 @@ subroutine cloud_indexing_logic_night(Ctrl, SPixel, is_not_used_or_missing, &
    else
       min_rho = MaxRho_XX
    end if
-   call Identify_BRDF_Terms(Ctrl, SPixel%Illum(1), 1, min_rho, &
+   call Identify_BRDF_Terms(Ctrl, Spixel%Illum, 1, min_rho, &
         is_not_used_or_missing, X, ii_x, XJ, ii_xj, XI, ii_xi, &
         SPixel%variables_retrieved, .false.)
 
@@ -765,24 +763,24 @@ subroutine cloud_indexing_logic_two_layer(Ctrl, SPixel, is_not_used_or_missing, 
    ii_xj = 0
    ii_xi = 0
 
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITau,  X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau,  X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IRe,   X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe,   X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IPc,   X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc,   X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITau2, X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau2, X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IRe2,  X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe2,  X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IPc2,  X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc2,  X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), ITs,   X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, ITs,   X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
 
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IFr,   X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, IFr,   X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .false.)
-   call Add_to_State_Vector(Ctrl, SPixel%Illum(1), IFr2,  X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, Spixel%Illum, IFr2,  X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .false.)
 
    ! Add BRDF terms to parameter vector
@@ -791,7 +789,7 @@ subroutine cloud_indexing_logic_two_layer(Ctrl, SPixel, is_not_used_or_missing, 
    else
       min_rho = MaxRho_XX
    end if
-   call Identify_BRDF_Terms(Ctrl, SPixel%Illum(1), 1, min_rho, &
+   call Identify_BRDF_Terms(Ctrl, Spixel%Illum, 1, min_rho, &
         is_not_used_or_missing, X, ii_x, XJ, ii_xj, XI, ii_xi, &
         SPixel%variables_retrieved, .false.)
 
@@ -846,7 +844,7 @@ subroutine aer_indexing_logic(Ctrl, SPixel, is_not_used_or_missing, &
 
 
    ! Daytime only
-   if (SPixel%Illum(1) /= IDay) then
+   if (Spixel%Illum /= IDay) then
       status = SPixelIndexing
       return
    end if
@@ -936,7 +934,7 @@ subroutine swan_indexing_logic(Ctrl, SPixel, is_not_used_or_missing, &
 
 
    ! Daytime only
-   if (SPixel%Illum(1) /= IDay) then
+   if (Spixel%Illum /= IDay) then
       status = SPixelIndexing
       return
    end if
@@ -1069,7 +1067,7 @@ subroutine aer_indexing_logic_1view(Ctrl, SPixel, is_not_used_or_missing, &
    integer, parameter :: min_view = 1 ! Only using a single view.
 
    ! Daytime only
-   if (SPixel%Illum(1) /= IDay) then
+   if (Spixel%Illum /= IDay) then
       status = SPixelIndexing
       return
    end if

--- a/src/get_indexing.F90
+++ b/src/get_indexing.F90
@@ -132,14 +132,14 @@ subroutine Get_Indexing(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
    ! and/or are flagged as missing.
    is_not_used_or_missing = .false.
 
-   if (Spixel%Illum .eq. IDay) then
+   if (SPixel%Illum .eq. IDay) then
       ! All channels are used
       do i_chan = 1, Ctrl%Ind%Ny
          if (MSI_Data%MSI(SPixel%Loc%X0, SPixel%Loc%Y0, i_chan) == sreal_fill_value) then
             is_not_used_or_missing(i_chan) = .true.
          end if
       end do
-   else if (Spixel%Illum .eq. ITwi)  then
+   else if (SPixel%Illum .eq. ITwi)  then
       ! Only pure thermal channels (no mixed) are used
       do i_chan = 1, Ctrl%Ind%Ny
          if (btest(Ctrl%Ind%Ch_Is(i_chan), SolarBit) .or. &
@@ -147,7 +147,7 @@ subroutine Get_Indexing(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
             is_not_used_or_missing(i_chan) = .true.
          end if
       end do
-   else if (Spixel%Illum .eq. INight) then
+   else if (SPixel%Illum .eq. INight) then
       ! All thermal channels (including mixed) are used
       do i_chan = 1, Ctrl%Ind%Ny
          if (.not. btest(Ctrl%Ind%Ch_Is(i_chan), ThermalBit) .or. &
@@ -164,7 +164,7 @@ subroutine Get_Indexing(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
    select case (Ctrl%Approach)
    case (AppCld1L)
       if (.not. Ctrl%do_new_night_retrieval &
-          .or. Spixel%Illum .eq. IDay .or. Spixel%Illum .eq. ITwi) then
+          .or. SPixel%Illum .eq. IDay .or. SPixel%Illum .eq. ITwi) then
          call cloud_indexing_logic(Ctrl, SPixel, is_not_used_or_missing, &
                                    X, XJ, XI, status)
       else
@@ -212,8 +212,8 @@ subroutine Get_Indexing(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
    end if
 
    ! Set the illumination-dependent first guess and a priori
-   SPixel%FG = Ctrl%FG(:,Spixel%Illum)
-   SPixel%AP = Ctrl%AP(:,Spixel%Illum)
+   SPixel%FG = Ctrl%FG(:,SPixel%Illum)
+   SPixel%AP = Ctrl%AP(:,SPixel%Illum)
 
    ! Set up all the channel indexes
    call setup_indexes(Ctrl, SAD_Chan, SPixel, is_not_used_or_missing)
@@ -267,13 +267,13 @@ subroutine setup_indexes(Ctrl, SAD_Chan, SPixel, is_not_used_or_missing)
          SPixel%Ind%Ny = SPixel%Ind%Ny + 1
 
          if (btest(Ctrl%Ind%Ch_Is(i), SolarBit) .and. &
-             Spixel%Illum .eq. IDay .and. &
+             SPixel%Illum .eq. IDay .and. &
              btest(Ctrl%Ind%Ch_Is(i), ThermalBit)) then
             SPixel%Ind%NMixed   = SPixel%Ind%NMixed + 1
          end if
 
          if (btest(Ctrl%Ind%Ch_Is(i), SolarBit) .and. &
-             Spixel%Illum .eq. IDay) then
+             SPixel%Illum .eq. IDay) then
             SPixel%Ind%NSolar   = SPixel%Ind%NSolar + 1
          end if
 
@@ -315,7 +315,7 @@ subroutine setup_indexes(Ctrl, SAD_Chan, SPixel, is_not_used_or_missing)
          cycle
 
       if (btest(Ctrl%Ind%Ch_Is(i), SolarBit) .and. &
-          Spixel%Illum .eq. IDay .and. &
+          SPixel%Illum .eq. IDay .and. &
           btest(Ctrl%Ind%Ch_Is(i), ThermalBit)) then
          ! Mixed channels out of those to be retrieved
          SPixel%Ind%YMixed(i2) = ii
@@ -325,7 +325,7 @@ subroutine setup_indexes(Ctrl, SAD_Chan, SPixel, is_not_used_or_missing)
       end if
 
       if (btest(Ctrl%Ind%Ch_Is(i), SolarBit) .and. &
-          Spixel%Illum .eq. IDay) then
+          SPixel%Illum .eq. IDay) then
          ! Solar channels out of those to be used
          SPixel%Ind%YSolar(i0) = ii
          SPixel%spixel_y_solar_to_ctrl_y_index(i0) = i
@@ -489,7 +489,7 @@ subroutine cloud_indexing_logic(Ctrl, SPixel, is_not_used_or_missing, &
    ! channels then pick the first one in Ctrl%ReChans that matches and set the
    ! rest of the Ctrl%ReChans that match to missing.  If Ctrl%ReChans is not
    ! associated it is assumed that all available r_e channels should be used.
-   if (Spixel%Illum .eq. IDay .and. associated(Ctrl%ReChans)) then
+   if (SPixel%Illum .eq. IDay .and. associated(Ctrl%ReChans)) then
       i_r_e_chan = 0
       do i_chan = 1, size(Ctrl%ReChans)
          ii_chan = find_in_array(Ctrl%r_e_chans, Ctrl%ReChans(i_chan))
@@ -550,29 +550,29 @@ subroutine cloud_indexing_logic(Ctrl, SPixel, is_not_used_or_missing, &
    ii_xi = 0
    n_ir_chans2 = n_ir_chans
    ! Retrieve Tau if sufficient appropriate channels are available
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, &
         active = n_tau_chans .ge. min_tau_chans)
    ! Retrieve Re if sufficient appropriate channels are available (if thermal
    ! channels used, decrement the IR channel counter)
    if (re_thermal) then
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe, X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, IRe, X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, &
            active = n_r_e_chans .ge. min_r_e_chans, ch_available = n_ir_chans2)
    else
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe, X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, IRe, X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, &
            active = n_r_e_chans .ge. min_r_e_chans)
    end if
    ! Pc, Ts, Fr retreved for all illumination. n_ir_chans2 ensures there aren't
    ! more things retrieved than there are measurements
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc, X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, IPc, X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, &
         active = n_ir_chans2 .ge. min_ir_chans, ch_available = n_ir_chans2)
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, ITs, X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, ITs, X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, &
         active = n_ir_chans2 .ge. min_ir_chans, ch_available = n_ir_chans2)
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, IFr, X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, IFr, X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, &
         active = n_ir_chans2 .ge. min_ir_chans, ch_available = n_ir_chans2)
 
@@ -582,7 +582,7 @@ subroutine cloud_indexing_logic(Ctrl, SPixel, is_not_used_or_missing, &
    else
       min_rho = MaxRho_XX
    end if
-   call Identify_BRDF_Terms(Ctrl, Spixel%Illum, 1, min_rho, &
+   call Identify_BRDF_Terms(Ctrl, SPixel%Illum, 1, min_rho, &
         is_not_used_or_missing, X, ii_x, XJ, ii_xj, XI, ii_xi, &
         SPixel%variables_retrieved, .false.)
 
@@ -653,44 +653,44 @@ subroutine cloud_indexing_logic_night(Ctrl, SPixel, is_not_used_or_missing, &
    ii_xi = 0
 
    if (n_chans .eq. 1) then
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .false.)
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, IRe,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .false.)
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, IPc,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITs,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, ITs,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .false.)
    else if (n_chans .eq. 2) then
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .false.)
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, IRe,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .false.)
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, IPc,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITs,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, ITs,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
    else if (n_chans .eq. 3) then
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, IRe,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, IPc,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITs,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, ITs,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
    else if (n_chans .ge. 4) then
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, ITau, X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, IRe,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, IPc,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-      call Add_to_State_Vector(Ctrl, Spixel%Illum, ITs,  X, ii_x, XJ, ii_xj, &
+      call Add_to_State_Vector(Ctrl, SPixel%Illum, ITs,  X, ii_x, XJ, ii_xj, &
            XI, ii_xi, SPixel%variables_retrieved, active = .true.)
    end if
 
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, IFr,  X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, IFr,  X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .false.)
 
    ! Add BRDF terms to parameter vector
@@ -699,7 +699,7 @@ subroutine cloud_indexing_logic_night(Ctrl, SPixel, is_not_used_or_missing, &
    else
       min_rho = MaxRho_XX
    end if
-   call Identify_BRDF_Terms(Ctrl, Spixel%Illum, 1, min_rho, &
+   call Identify_BRDF_Terms(Ctrl, SPixel%Illum, 1, min_rho, &
         is_not_used_or_missing, X, ii_x, XJ, ii_xj, XI, ii_xi, &
         SPixel%variables_retrieved, .false.)
 
@@ -763,24 +763,24 @@ subroutine cloud_indexing_logic_two_layer(Ctrl, SPixel, is_not_used_or_missing, 
    ii_xj = 0
    ii_xi = 0
 
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau,  X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, ITau,  X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe,   X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, IRe,   X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc,   X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, IPc,   X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, ITau2, X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, ITau2, X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, IRe2,  X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, IRe2,  X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, IPc2,  X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, IPc2,  X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, ITs,   X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, ITs,   X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .true.)
 
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, IFr,   X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, IFr,   X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .false.)
-   call Add_to_State_Vector(Ctrl, Spixel%Illum, IFr2,  X, ii_x, XJ, ii_xj, &
+   call Add_to_State_Vector(Ctrl, SPixel%Illum, IFr2,  X, ii_x, XJ, ii_xj, &
         XI, ii_xi, SPixel%variables_retrieved, active = .false.)
 
    ! Add BRDF terms to parameter vector
@@ -789,7 +789,7 @@ subroutine cloud_indexing_logic_two_layer(Ctrl, SPixel, is_not_used_or_missing, 
    else
       min_rho = MaxRho_XX
    end if
-   call Identify_BRDF_Terms(Ctrl, Spixel%Illum, 1, min_rho, &
+   call Identify_BRDF_Terms(Ctrl, SPixel%Illum, 1, min_rho, &
         is_not_used_or_missing, X, ii_x, XJ, ii_xj, XI, ii_xi, &
         SPixel%variables_retrieved, .false.)
 
@@ -844,7 +844,7 @@ subroutine aer_indexing_logic(Ctrl, SPixel, is_not_used_or_missing, &
 
 
    ! Daytime only
-   if (Spixel%Illum /= IDay) then
+   if (SPixel%Illum /= IDay) then
       status = SPixelIndexing
       return
    end if
@@ -934,7 +934,7 @@ subroutine swan_indexing_logic(Ctrl, SPixel, is_not_used_or_missing, &
 
 
    ! Daytime only
-   if (Spixel%Illum /= IDay) then
+   if (SPixel%Illum /= IDay) then
       status = SPixelIndexing
       return
    end if
@@ -1067,7 +1067,7 @@ subroutine aer_indexing_logic_1view(Ctrl, SPixel, is_not_used_or_missing, &
    integer, parameter :: min_view = 1 ! Only using a single view.
 
    ! Daytime only
-   if (Spixel%Illum /= IDay) then
+   if (SPixel%Illum /= IDay) then
       status = SPixelIndexing
       return
    end if

--- a/src/get_indexing.F90
+++ b/src/get_indexing.F90
@@ -125,6 +125,11 @@ subroutine Get_Indexing(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
       end if
    end do
 
+   ! Force nighttime retrieval
+   if (Ctrl%force_nighttime_retrieval) then
+      SPixel%Illum(:) = INight
+   end if
+
    ! Find which channels are either not used based on illumination conditions
    ! and/or are flagged as missing.
    is_not_used_or_missing = .false.

--- a/src/get_measurements.F90
+++ b/src/get_measurements.F90
@@ -191,7 +191,7 @@ subroutine Get_Measurements(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
          end if
 
          ! Daylight
-         if (Spixel%Illum .ne. INight .and. Spixel%Illum .ne. ITwi) then
+         if (SPixel%Illum .ne. INight .and. SPixel%Illum .ne. ITwi) then
             if (SAD_Chan(ii)%Solar%Flag /= 0) then
                if (SAD_Chan(ii)%Thermal%Flag /= 0) then
                   ! Both solar and thermal => mixed
@@ -228,7 +228,7 @@ subroutine Get_Measurements(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
          ii = SPixel%spixel_y_to_ctrl_y_index(i)
 
          ! Daylight
-         if (Spixel%Illum == IDay) then
+         if (SPixel%Illum == IDay) then
             if (SAD_Chan(ii)%Solar%Flag /= 0) then
                if (SAD_Chan(ii)%Thermal%Flag /= 0) then
                   ! both solar and thermal => mixed

--- a/src/get_measurements.F90
+++ b/src/get_measurements.F90
@@ -191,7 +191,7 @@ subroutine Get_Measurements(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
          end if
 
          ! Daylight
-         if (SPixel%Illum(1) .ne. INight .and. SPixel%Illum(1) .ne. ITwi) then
+         if (Spixel%Illum .ne. INight .and. Spixel%Illum .ne. ITwi) then
             if (SAD_Chan(ii)%Solar%Flag /= 0) then
                if (SAD_Chan(ii)%Thermal%Flag /= 0) then
                   ! Both solar and thermal => mixed
@@ -228,7 +228,7 @@ subroutine Get_Measurements(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
          ii = SPixel%spixel_y_to_ctrl_y_index(i)
 
          ! Daylight
-         if (SPixel%Illum(1) == IDay) then
+         if (Spixel%Illum == IDay) then
             if (SAD_Chan(ii)%Solar%Flag /= 0) then
                if (SAD_Chan(ii)%Thermal%Flag /= 0) then
                   ! both solar and thermal => mixed

--- a/src/read_driver.F90
+++ b/src/read_driver.F90
@@ -236,6 +236,7 @@ subroutine Read_Driver(Ctrl, global_atts, source_atts)
    Ctrl%do_CTX_correction      = .true.
    Ctrl%process_cloudy_only    = .true.
    Ctrl%process_aerosol_only   = .false.
+   Ctrl%force_nighttime_retrieval = .false.
 
 
    !----------------------------------------------------------------------------

--- a/src/spixel.F90
+++ b/src/spixel.F90
@@ -234,7 +234,7 @@ module SPixel_m
       integer(byte)       :: Type         ! Particle type in pixel
       type(Surface_t)     :: Surface      ! Super-pixel surface flag info
       type(SPixel_Ind_t)  :: Ind          ! Numbers and indices of channels
-      integer, pointer    :: Illum(:)     ! Illumination flag (day,twi, night)
+      integer             :: Illum        ! Illumination flag (IDay, ITwi or INight)
       real,    pointer    :: f0(:)        ! Solar constant
       integer             :: FG(MaxStateVar)
                                           ! Methods for setting first guess

--- a/src/x_mdad.F90
+++ b/src/x_mdad.F90
@@ -144,7 +144,7 @@ subroutine X_MDAD(Ctrl, SPixel, index, X, status, Err)
 
    case (ITau, ITau2) ! Cloud optical depth, Tau
 
-      if (SPixel%Illum(1) == IDay .and. i_spixel_06_solar > 0) then
+      if (Spixel%Illum == IDay .and. i_spixel_06_solar > 0) then
          ! Calculate overcast reflectance (assuming fully cloudy pixel).
          ! Uses channel nearest 0.67 microns, index Ctrl%Ind%MDAD_SW.
          Ref_o = SPixel%Ym(i_spixel_06) - SPixel%Surface%Rs(i_spixel_06_solar)

--- a/src/x_mdad.F90
+++ b/src/x_mdad.F90
@@ -144,7 +144,7 @@ subroutine X_MDAD(Ctrl, SPixel, index, X, status, Err)
 
    case (ITau, ITau2) ! Cloud optical depth, Tau
 
-      if (Spixel%Illum == IDay .and. i_spixel_06_solar > 0) then
+      if (SPixel%Illum == IDay .and. i_spixel_06_solar > 0) then
          ! Calculate overcast reflectance (assuming fully cloudy pixel).
          ! Uses channel nearest 0.67 microns, index Ctrl%Ind%MDAD_SW.
          Ref_o = SPixel%Ym(i_spixel_06) - SPixel%Surface%Rs(i_spixel_06_solar)


### PR DESCRIPTION
I've added a flag to force ORAC into thinking it's nighttime regardless of whether it is or it isn't. This is useful for running the retrieval during the day with only thermal channels (so far I'm finding good results when applying it to volcanic ash clouds). I force the retrieval into using nighttime cloud indexing logic by setting `SPixel%Illum(:) = INight` in get_indexing.F90 which subsequently triggers the `cloud_indexing_logic_night` routine. One potential issue is that if `SPixel%Illum` is written out to any of the preproc ancillary files (I haven't checked) then the flag values would be output as night when it's actually day (or twilight).