### PR TITLE
Update to the aerosol retrieval

### DIFF
--- a/src/check_limits.F90
+++ b/src/check_limits.F90
@@ -66,8 +66,10 @@ subroutine Check_Limits(Ctrl, X, SPixel, status)
    do i = 1, SPixel%Nx
       if (X(SPixel%X(i)) > SPixel%XULim(SPixel%X(i))) then
           X(SPixel%X(i)) = SPixel%XULim(SPixel%X(i))
+          status = LimitHitUpper
        else if (X(SPixel%X(i)) < SPixel%XLLim(SPixel%X(i))) then
           X(SPixel%X(i)) = SPixel%XLLim(SPixel%X(i))
+          status = LimitHitLower
        end if
    end do
 
@@ -84,6 +86,7 @@ subroutine Check_Limits(Ctrl, X, SPixel, status)
                   P_mid = (X(IPc) + X(IPc2)) / 2.
                   X(IPc)  = P_mid - Ctrl%Invpar%Pc_dmz / 2.
                   X(IPc2) = P_mid + Ctrl%Invpar%Pc_dmz / 2.
+                  status = LimitHitClose
                end if
                exit L1
             end if

--- a/src/diag.F90
+++ b/src/diag.F90
@@ -38,6 +38,7 @@ module Diag_m
                                     ! - bits 1 to SPixel%Nx: set to 1 if
                                     !   parameter's estimated retrieval
                                     !   uncertainty too large
+      integer       :: LimitHit     ! Has the retrieval ever hit a limit?
       integer       :: Iterations   ! Number of iterations taken by inversion
                                     ! scheme to reach convergence
       real          :: Jm           ! Cost at solution due to measurements

--- a/src/invert_marquardt.F90
+++ b/src/invert_marquardt.F90
@@ -271,6 +271,7 @@ subroutine Invert_Marquardt(Ctrl, SPixel, SAD_Chan, SAD_LUT, RTM_Pc, Diag, stat)
                                   ! "Model parameter" error covariance.
    real    :: St_temp(SPixel%Nx, SPixel%Nx)
                                   ! Array temporary for Diag%St
+   integer :: limit_hit           ! Indicates if state vector hits a limit
    real, dimension(SPixel%Ind%NSolar)    :: CRP, T_00, T_0d, T_all
    real, dimension(SPixel%Ind%NSolar, 2) :: d_CRP, d_T_00, d_T_0d
    real    :: CRP_thermal(SPixel%Ind%NThermal)
@@ -410,8 +411,8 @@ subroutine Invert_Marquardt(Ctrl, SPixel, SAD_Chan, SAD_LUT, RTM_Pc, Diag, stat)
 
       ! Check bounds for active state variables - does delta_X take any state
       ! variable outside it's range? (If so, freeze it at the boundary).
-      call Check_Limits(Ctrl, Xplus_dX, SPixel, stat)
-      if (stat /= 0) go to 99 ! Terminate processing this pixel
+      call Check_Limits(Ctrl, Xplus_dX, SPixel, limit_hit)
+      if (limit_hit /= 0) Diag%LimitHit = limit_hit
 
       ! ************ START EVALUATE FORWARD MODEL ************
       call FM(Ctrl, SPixel, SAD_Chan, SAD_LUT, RTM_Pc, Xplus_dX, Y, dY_dX, stat)

--- a/src/orac_constants.F90
+++ b/src/orac_constants.F90
@@ -268,7 +268,7 @@ module ORAC_constants_m
    integer, parameter :: DoFNBit          = 4
    integer, parameter :: ElevBit          = 5
    integer, parameter :: GlintBit         = 6
-
+   integer, parameter :: LimitBit         = 7
 
    ! Retrieval classes (for Ctrl%Class)
    integer, parameter :: ClsCldWat        = 1
@@ -431,5 +431,10 @@ module ORAC_constants_m
 
    ! Shuffling to improve compression
    logical, parameter :: shuffle_flag  = .False.
+
+   ! Indicator that the retrieval hit a limit
+   integer, parameter :: LimitHitUpper = 1
+   integer, parameter :: LimitHitLower = 2
+   integer, parameter :: LimitHitClose = 3
 
 end module ORAC_constants_m

--- a/src/prepare_output.F90
+++ b/src/prepare_output.F90
@@ -143,7 +143,7 @@ subroutine build_flag_masks(Ctrl, data)
    character(len=8)  :: state_label
 
    data%qc_flag_masks    = '1b'
-   do i = 1, 6
+   do i = 1, 7
       write(temp_str, '(I14)') 2_dint**i
       data%qc_flag_masks = trim(data%qc_flag_masks) // ' ' // &
            trim(adjustl(temp_str)) // 'b'
@@ -166,7 +166,8 @@ subroutine build_flag_masks(Ctrl, data)
    write(temp_str,"(f14.1)") Ctrl%MinRelAzi
    data%qc_flag_meanings = trim(data%qc_flag_meanings) // ' ' // &
                            '64: Sun glint (relative azimuth < ' // &
-                                trim(adjustl(temp_str)) // ' deg)'
+                                trim(adjustl(temp_str)) // ' deg) ' // &
+                           '128: Retrieval hit an imposed limit'
 
    data%ch_flag_masks    = '2b'
    data%ch_flag_meanings = 'Ch1_used'

--- a/src/read_driver.F90
+++ b/src/read_driver.F90
@@ -592,7 +592,7 @@ subroutine Read_Driver(Ctrl, global_atts, source_atts)
 
    !----------------------- Ctrl%QC -----------------------
    Ctrl%QC%MaxJ         = switch_app(a, Default=100.0, Aer=3.0)
-   Ctrl%QC%MaxDoFN      = switch_app(a, Default=2.0)
+   Ctrl%QC%MaxDoFN      = switch_app(a, Default=1.0)
    Ctrl%QC%MaxElevation = switch_app(a, Default=1500.0)
 
    !------------------- Ctrl START/END POINT --------------

--- a/src/read_driver.F90
+++ b/src/read_driver.F90
@@ -1070,7 +1070,7 @@ subroutine Read_Driver(Ctrl, global_atts, source_atts)
             X_Dy(Nx_Dy) = ISS(i)
          end if
       end do
-      do i = 1, Ctrl%Ind%NViews
+      do i = 2, Ctrl%Ind%NViews
          Nx_Dy = Nx_Dy+1
          X_Dy(Nx_Dy) = ISP(i)
       end do

--- a/src/set_diag.F90
+++ b/src/set_diag.F90
@@ -121,6 +121,7 @@ subroutine Set_Diag(Ctrl, SPixel, MSI_Data, Diag)
    if (any(SPixel%Geom%RelAzi < Ctrl%MinRelAzi) .and. &
         .not. (Ctrl%Approach == AppCld1L .or. Ctrl%Approach == AppCld2L)) &
                                      Diag%QCFlag = ibset(Diag%QCFlag, GlintBit)
+   if (Diag%LimitHit /= 0)           Diag%QCFlag = ibset(Diag%QCFlag, LimitBit)
    ! Cirrus contamination
    ! Case 2 waters
    ! Shadows

--- a/src/zero_diag.F90
+++ b/src/zero_diag.F90
@@ -55,6 +55,7 @@ subroutine Zero_Diag(Ctrl, Diag)
 
    Diag%Converged          = .false.
    Diag%QCFlag             = -1
+   Diag%LimitHit           = 0
    Diag%Iterations         = 0
    Diag%Jm                 = MissingSn
    Diag%Ja                 = MissingSn


### PR DESCRIPTION
This pull request does three things:

- Add a new term to the `QCFlag` bitmask indicating when the retrieval has used `check_limits()` at any point during its iteration.
- Removes the nadir angular term from the state vector for `AppAerSw` retrievals.
- Reduce the acceptable number of degrees of freedom for noise to 1.0 as, with the change above, that is the point at which retrievals appear to become unconstrained.

The first is hopefully useful for all retrieval modes, but was added to identify a large number of barely converged retrievals of 0.01 optical depth in the aerosol retrieval over land. 

The second only affects aerosol retrievals over land. I find it reduces the number of iterations needed to converge, ensures that the number of degrees of freedom for noise behaves similarly to other retrieval modes, and improves agreement with AERONET. But it means we have a second arbitrary parameter in the Swansea forward model (the other being gamma).

The third will only affect processing that requires `QCFlag == 0`. Having eliminated the unconstrained variable, I now find that the retrieval behaves erratically when there is an entire degree of freedom for noise. (To be specific, in most circumstances the DoFN increase as the AOD decrease but, once DoFN >= 1, we tend to get AOD == 0.01 and erratic values of AER.)