### PR TITLE
Update new LUT netcdf reader and add functionality for varying NEBT/NEFR uncertainty with measurements

### DIFF
--- a/src/ctrl.F90
+++ b/src/ctrl.F90
@@ -102,6 +102,7 @@
 ! 2017/07/05, AP: Add NAll to track the total number of channels. New QC.
 ! 2017/10/04, GM: Add use_ann_phase.
 ! 2021/04/06, AP: New LUT names.
+! 2021/10/12, ATP: Add new LUT netcdf filenames.
 !
 ! Bugs:
 ! None known.
@@ -122,6 +123,8 @@ module Ctrl_m
       character(FilenameLen) :: SAD_Dir2           ! Directory of SAD files
       character(FilenameLen) :: Filename           ! Basename of input files
       character(FilenameLen) :: Config             ! Configuration
+      character(FilenameLen) :: NCDF_LUT_Filename  ! Filename of NCDF LUT
+      character(FilenameLen) :: NCDF_LUT_Filename2 ! Filename of NCDF LUT (multi-layer)
       character(FilenameLen) :: MSI                ! Multi-Spectral Image
       character(FilenameLen) :: LWRTM              ! LW Rad Trans Model results
       character(FilenameLen) :: SWRTM              ! SW Rad Trans Model results

--- a/src/get_measurements.F90
+++ b/src/get_measurements.F90
@@ -91,7 +91,9 @@
 ! 2015/01/30, AP: Replace YSeg0 with Y0 as superpixeling removed.
 ! 2015/08/19, AP: Sy may now be drawn from the MSI data files (SelmMeas), the
 !    SAD files (SelmAux), or taken to be constant (SelmCtrl).
-!
+! 2021/10/12, ATP: Implement NEBT and NEDR that vary with the measurements.
+!    This requires the new (netcdf) LUTs. When using netcdf LUTs,
+!    Homog and Coreg noise are independent of LUT being used.
 ! Bugs:
 ! None known.
 !-------------------------------------------------------------------------------
@@ -107,7 +109,6 @@ subroutine Get_Measurements(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
    implicit none
 
    ! Define arguments
-
    type(Ctrl_t),     intent(in)    :: Ctrl
    type(SAD_Chan_t), intent(in)    :: SAD_Chan(:)
    type(SPixel_t),   intent(inout) :: SPixel
@@ -115,13 +116,28 @@ subroutine Get_Measurements(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
    integer,          intent(out)   :: status
 
    ! Define local variables
-
    integer :: i, ii, j, jj
-   real    :: Rad(1)   ! Radiance calculated from noise equivalent brightness
-                       ! temperature used in setting Sy for mixed thermal /
-                       ! solar channels.
-   real    :: dR_dT(1) ! Gradient of Rad w.r.t temp.
+   real    :: Rad(1)    ! Radiance calculated from noise equivalent brightness
+                        ! temperature used in setting Sy for mixed thermal /
+                        ! solar channels.
+   real    :: dR_dT(1)  ! Gradient of Rad w.r.t temp.
 
+   ! Define variables for computing reflectance varying NEDR
+   real    :: Lx        ! Radiance measurement
+   real    :: dLx       ! Radiance uncertainty
+   real    :: gain(11)  ! Radiance gain for MSG3 SEVIRI tests (TO BE REMOVED).
+
+   ! Define variables for computing brightness temperature-varying NEBT.
+   real    :: dR_dT0(1) ! Gradient of Rad w.r.t. reference temperature.
+   real    :: dR_dTm(1) ! Gradient of Rad w.r.t. measured temperature.
+   real    :: R0(1)     ! Radiance calculated reference temperature.
+   real    :: Rm(1)     ! Radiance calculated measured temperature.
+
+   ! Homogeneity (Homog) and Co-registration (Coreg) noise
+   real    :: ThermalNeHomog   ! Homog noise for thermal channels
+   real    :: SolarNeHomog     ! Homog noise for solar channels
+   real    :: ThermalNeCoreg   ! Coreg noise for thermal channels
+   real    :: SolarNeCoreg     ! Coreg noise for solar channels
 
    status = 0
 
@@ -158,13 +174,47 @@ subroutine Get_Measurements(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
                           MSI_Data%SD(SPixel%Loc%X0, SPixel%Loc%Y0, ii)
       end do
    case(SelmAux)
+      ! These are gains from the header of SEVIRI MSG3 *.nat files
+      ! read in using Satpy for the nominal calibration.
+      gain(:) = (/0.02142, 0.02829, 0.02370, &
+                 0., 0., 0., 0., 0., 0., 0., 0./)
+
       ! Use values read from SAD_Chan files
       do i = 1, SPixel%Ind%Ny
          ii = SPixel%spixel_y_to_ctrl_y_index(i)
          if (SAD_Chan(ii)%Thermal%Flag > 0) then
-            SPixel%Sy(i,i) = SAD_Chan(ii)%Thermal%NEBT
+            if (len_trim(Ctrl%LUTClass) == 3) then
+               ! Old LUTs approach (fixed uncertainty)
+               ! Note: NEBT is already squared when old LUT is read in.
+               SPixel%Sy(i,i) = SAD_Chan(ii)%Thermal%NEBT
+            else
+               ! New LUTs approach (varying uncertainty)
+               ! Note: NEBT is NOT squared when new LUT is read in.
+               call T2R(1, SAD_Chan(ii:ii), SAD_Chan(ii:ii)%Thermal%T0, R0, dR_dT0, status)
+               call T2R(1, SAD_Chan(ii:ii), SPixel%Ym(i:i), Rm, dR_dTm, status)
+               ! Convert to variance by squaring uncertainty
+               SPixel%Sy(i,i) = (SAD_Chan(ii)%Thermal%NEBT * &
+                                 (dR_dT0(1) / dR_dTm(1))) ** 2
+            end if
          else
-            SPixel%Sy(i,i) = SAD_Chan(ii)%Solar%NedR
+            if (len_trim(Ctrl%LUTClass) == 3) then
+               ! Old LUTs approach (fixed uncertainty)
+               ! Note: NEDR is squared when old LUT is read in.
+               SPixel%Sy(i,i) = SAD_Chan(ii)%Solar%NEDR
+            else
+               ! New LUTs approach (varying uncertainty)
+               ! Convert reflectance to radiance
+               Lx = (SPixel%Ym(i) * cos(SPixel%Geom%SolZen(i) * d2r) * &
+                     SAD_Chan(ii)%Solar%F0) / Pi
+               ! Compute uncertainty in terms of radiance
+               dLx = sqrt((Lx / SAD_Chan(ii)%Solar%SNR ) ** 2 + &
+                           2 * ((gain(ii) * (1.0 / sqrt(12.0))) ** 2))
+               ! Convert radiance uncertainty to reflectance uncertainty
+               ! then square it to convert to reflectance variance
+               SPixel%Sy(i,i) = ((Pi * dLx) / &
+                                (cos(SPixel%Geom%SolZen(i) * d2r) * &
+                                 SAD_Chan(ii)%Solar%F0)) ** 2
+            end if
          end if
       end do
    case(SelmCtrl)
@@ -183,6 +233,21 @@ subroutine Get_Measurements(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
    ! thermal and solar contributions).
 
    if (Ctrl%EqMPN%Homog) then
+      ! Set values for cloud homogeneity noise to account for errors due
+      ! to the plane-parallel cloud assumption. Values are taken from
+      ! Table 4 in Watts et al. (2011) and were originally calculated
+      ! for a pre-launch SEVIRI using ASTR-2 data (Watts et al., 1998).
+      ! Originally, 5 different values were set for each cloud type.
+      ! However, as we do not classify clouds by type, only a single
+      ! value is used. Currently, we take the maximum value reported
+      ! in Table 4 of Watts et al. (2011) for thermal and solar channels,
+      ! acknowledging that these values need revision in the future.
+      ! In addition, these values are now set independent of the
+      ! instrument as they are forward model errors. Legacy values for
+      ! Homog can be found in the old *.sad files for each instrument.
+      ThermalNeHomog = 0.50  ! K (absolute error)
+      SolarNeHomog = 1.0 ! % of total signal (fractional error)
+
       do i = 1, SPixel%Ind%Ny
          ii = SPixel%spixel_y_to_ctrl_y_index(i)
 
@@ -196,34 +261,73 @@ subroutine Get_Measurements(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
                if (SAD_Chan(ii)%Thermal%Flag /= 0) then
                   ! Both solar and thermal => mixed
 
-                  ! Convert NedR to brightness temperature and add to Sy
-                  ! Also add in the thermal contribution to Sy
+                  ! Compute partial derivative of Planck function w.r.t.
+                  ! T, evaluated at the measured BT and wavelength of
+                  ! mixed channel and store result in dR_dT(1).
                   call T2R(1, SAD_Chan(ii:ii), SPixel%Ym(i:i), Rad, dR_dT, status)
-                  SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
-                     SAD_Chan(ii)%Thermal%NeHomog(Ctrl%CloudType) + &
-                     SAD_Chan(ii)%Solar%NeHomog(Ctrl%CloudType) * &
-                     SAD_Chan(ii)%Solar%f0*SAD_Chan(ii)%Solar%f0 / &
-                     (dR_dT(1)*dR_dT(1))
+                  if (len_trim(Ctrl%LUTClass) == 3) then
+                     ! Old LUTs approach reads homog from sad files.
+                     SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
+                             SAD_Chan(ii)%Thermal%NeHomog(Ctrl%CloudType) + &
+                             SAD_Chan(ii)%Solar%NeHomog(Ctrl%CloudType) * &
+                             SAD_Chan(ii)%Solar%f0*SAD_Chan(ii)%Solar%f0 / &
+                             (dR_dT(1)*dR_dT(1))
+                  else
+                     ! New LUTs approach uses homog value hard-coded above.
+                     ! Add solar and thermal contributions of homog noise
+                     ! in units of Kelvin^2 to Sy by multiplying
+                     ! solar contribution by (F0/dR_dT)^2.
+                     SPixel%Sy(i,i) = SPixel%Sy(i,i) + ThermalNeHomog ** 2 &
+                             + ((SolarNeHomog/100.) * SAD_Chan(ii)%Solar%F0 / dR_dT(1)) ** 2
+                  end if
 
                else
-                  ! Pure solar channel, just add the solar NedR contribution
-                  SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
-                     SAD_Chan(ii)%Solar%NeHomog(Ctrl%CloudType) * &
-                     SPixel%Ym(i) * SPixel%Ym(i)
+                  ! Pure solar channel, just add the solar NedR contribution.
+                  if (len_trim(Ctrl%LUTClass) == 3) then
+                     ! Old LUTs approach reads homog from sad files.
+                     SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
+                             SAD_Chan(ii)%Solar%NeHomog(Ctrl%CloudType) * &
+                             SPixel%Ym(i) * SPixel%Ym(i)
+                  else
+                     ! New LUTs approach uses homog value hard-coded above.
+                     SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
+                             ((SolarNeHomog/100.) * SPixel%Ym(i)) ** 2
+                  end if
                end if
             end if
-
-         ! Night/twilight, only thermal channel info required
          else
+            ! Night/twilight, only thermal channel info required
             if (SAD_Chan(ii)%Thermal%Flag /= 0) then
-               SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
-                  SAD_Chan(ii)%Thermal%NeHomog(Ctrl%CloudType)
+               ! Pure thermal channel, add the thermal contribution to
+               ! Sy by squaring absolute uncertainties.
+               if (len_trim(Ctrl%LUTClass) == 3) then
+                  ! Old LUTs approach reads homog from sad files.
+                  SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
+                          SAD_Chan(ii)%Thermal%NeHomog(Ctrl%CloudType)
+               else
+                  ! New LUTs approach uses homog value hard-coded above.
+                  SPixel%Sy(i,i) = SPixel%Sy(i,i) + ThermalNeHomog ** 2
+               end if
             end if
          end if
       end do
    end if ! End of Homog noise section
 
    if (Ctrl%EqMPN%Coreg) then
+      ! Set values for co-registration noise to account for errors due
+      ! to different IFOVs between channels. Currently, we take the
+      ! maximum value reported in Table 4 of Watts et al. (2011)
+      ! for thermal and solar channels. In the future, these values
+      ! should vary based on channel and be reported as a pixel offset
+      ! in metres or pixel fraction and then converted to a BT or
+      ! reflectance by applying the associated pixel shifts as in
+      ! Watts et al. (1998). This approach would allow Coreg noise to
+      ! be scene and instrument dependent and would therefore not be
+      ! considered a forward model error. Legacy values for Coreg can
+      ! be found in the old *.sad files for each instrument.
+      ThermalNeCoreg = 0.15  ! K (absolute error)
+      SolarNeCoreg = 2.0 ! % of total signal (fractional error)
+
       do i = 1, SPixel%Ind%Ny
          ii = SPixel%spixel_y_to_ctrl_y_index(i)
 
@@ -231,29 +335,55 @@ subroutine Get_Measurements(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
          if (SPixel%Illum(1) == IDay) then
             if (SAD_Chan(ii)%Solar%Flag /= 0) then
                if (SAD_Chan(ii)%Thermal%Flag /= 0) then
-                  ! both solar and thermal => mixed
+                  ! Both solar and thermal => mixed
 
-                  ! Convert NedR to brightness temperature and add to Sy
-                  ! Also add in the thermal contribution to Sy
+                  ! Compute partial derivative of Planck function w.r.t.
+                  ! T, evaluated at the measured BT and wavelength of
+                  ! mixed channel and store result in dR_dT(1).
                   call T2R(1, SAD_Chan(ii:ii), SPixel%Ym(i:i), Rad, dR_dT, status)
-                  SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
-                     SAD_Chan(ii)%Thermal%NeCoreg(Ctrl%CloudType) + &
-                     SAD_Chan(ii)%Solar%NeCoreg(Ctrl%CloudType) * &
-                      SAD_Chan(ii)%Solar%f0*SAD_Chan(ii)%Solar%f0 / &
-                      (dR_dT(1)*dR_dT(1))
+                  if (len_trim(Ctrl%LUTClass) == 3) then
+                     ! Old LUTs approach reads coreg from sad files.
+                     SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
+                             SAD_Chan(ii)%Thermal%NeCoreg(Ctrl%CloudType) + &
+                             SAD_Chan(ii)%Solar%NeCoreg(Ctrl%CloudType) * &
+                             SAD_Chan(ii)%Solar%f0*SAD_Chan(ii)%Solar%f0 / &
+                             (dR_dT(1)*dR_dT(1))
+                  else
+                     ! New LUTs approach uses coreg value hard-coded above.
+                     ! Add solar and thermal contributions of coreg noise
+                     ! in units of Kelvin^2 to Sy by multiplying
+                     ! solar contribution by (F0/dR_dT)^2.
+                     SPixel%Sy(i,i) = SPixel%Sy(i,i) + ThermalNeCoreg ** 2 &
+                             + ((SolarNeCoreg/100.) * SAD_Chan(ii)%Solar%F0 / dR_dT(1)) ** 2
+                  end if
 
-               else ! Pure solar channel, just add the solar NedR contribution
-                  SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
-                     SAD_Chan(ii)%Solar%NeCoreg(Ctrl%CloudType) * &
-                     SPixel%Ym(i) * SPixel%Ym(i)
+               else
+                  ! Pure solar channel, just add the solar NedR contribution.
+                  if (len_trim(Ctrl%LUTClass) == 3) then
+                     ! Old LUTs approach reads coreg from sad files.
+                     SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
+                             SAD_Chan(ii)%Solar%NeCoreg(Ctrl%CloudType) * &
+                                     SPixel%Ym(i) * SPixel%Ym(i)
+                  else
+                     ! New LUTs approach uses coreg value hard-coded above.
+                     SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
+                             ((SolarNeCoreg/100.) * SPixel%Ym(i)) ** 2
+                  end if
                end if
             end if
-
-         ! Night/twilight, only thermal channel info required
          else
+            ! Night/twilight, only thermal channel info required
             if (SAD_Chan(ii)%Thermal%Flag /= 0) then
-               SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
-                  SAD_Chan(ii)%Thermal%NeCoreg(Ctrl%CloudType)
+               ! Pure thermal channel, add the thermal contribution to
+               ! Sy by squaring absolute uncertainties.
+               if (len_trim(Ctrl%LUTClass) == 3) then
+                  ! Old LUTs approach reads coreg from sad files.
+                  SPixel%Sy(i,i) = SPixel%Sy(i,i) + &
+                          SAD_Chan(ii)%Thermal%NeCoreg(Ctrl%CloudType)
+               else
+                  ! New LUTs approach uses coreg value hard-coded above.
+                  SPixel%Sy(i,i) = SPixel%Sy(i,i) + ThermalNeCoreg ** 2
+               end if
             end if
          end if
       end do

--- a/src/orac.F90
+++ b/src/orac.F90
@@ -328,8 +328,7 @@ subroutine orac(mytask,ntasks,lower_bound,upper_bound,drifile)
    ! parameters and read the SAD values.
    allocate(SAD_Chan(Ctrl%Ind%Ny))
 
-   call Read_SAD(Ctrl, global_atts%platform, SAD_Chan, SAD_LUT)
-
+   call Read_SAD(Ctrl, SAD_Chan, SAD_LUT)
 
    ! Make read in rttov data in one go, no more segment reads
    if (Ctrl%RTMIntSelm /= RTMIntMethNone) then

--- a/src/read_sad.F90
+++ b/src/read_sad.F90
@@ -44,7 +44,7 @@ implicit none
 
 contains
 
-subroutine Read_SAD(Ctrl, platform, SAD_Chan, SAD_LUT)
+subroutine Read_SAD(Ctrl, SAD_Chan, SAD_LUT)
 
    use Ctrl_m
    use ORAC_Constants_m
@@ -55,13 +55,12 @@ subroutine Read_SAD(Ctrl, platform, SAD_Chan, SAD_LUT)
 
    ! Argument declarations
    type(Ctrl_t),     intent(in)    :: Ctrl
-   character(len=*), intent(in)    :: platform
    type(SAD_Chan_t), intent(inout) :: SAD_Chan(:)
    type(SAD_LUT_t),  intent(inout) :: SAD_LUT(:)
 
    if (Ctrl%verbose) write(*,*) 'Reading SAD files'
 
-   if (len_trim(Ctrl%LUTClass) <= 3) then
+   if (len_trim(Ctrl%LUTClass) == 3) then
       ! Read channel sad files
       call Read_SAD_Chan(Ctrl, SAD_Chan)
 
@@ -72,9 +71,11 @@ subroutine Read_SAD(Ctrl, platform, SAD_Chan, SAD_LUT)
       end if
    else
       ! New NetCDF LUTs
-      call Read_NCDF_SAD_LUT(Ctrl, platform, Ctrl%LUTClass, SAD_LUT(1), SAD_Chan)
+      call Read_NCDF_SAD_LUT(Ctrl, Ctrl%FID%NCDF_LUT_Filename, &
+              SAD_Chan, SAD_LUT(1))
       if (Ctrl%Approach == AppCld2L) then
-         call Read_NCDF_SAD_LUT(Ctrl, platform, Ctrl%LUTClass2, SAD_LUT(2))
+         call Read_NCDF_SAD_LUT(Ctrl, Ctrl%FID%NCDF_LUT_Filename2, &
+                 SAD_Chan, SAD_LUT(2))
       end if
    end if
 

--- a/src/sad_chan.F90
+++ b/src/sad_chan.F90
@@ -18,6 +18,8 @@
 ! 2015/08/14, AP: Replace Find_MDAD() with generalised Find_Channel().
 ! 2015/08/21, AP: Move make_sad_filename() here from ReadSADLUT.
 ! 2017/06/21, OS: string name fix for METOP
+! 2021/10/12, ATP: Add reference brightness temperature (T0) to
+!    Thermal type and signal-to-noise ratio (SNR) to Solar type.
 !
 ! Bugs:
 ! None known.
@@ -46,6 +48,7 @@ module SAD_Chan_m
       real        :: NeCoreg(MaxCloudType) ! Coregistration noise
       real        :: NedR        ! Noise equivalent delta radiance
       real        :: Rs(2)       ! 'Typical' land/sea reflectance
+      real        :: SNR         ! Signal-to-noise ratio
    end type Solar_t
 
    type Thermal_t
@@ -54,6 +57,7 @@ module SAD_Chan_m
       real        :: B2          ! Planck function coefficient
       real        :: T1          ! Planck function coefficient
       real        :: T2          ! Planck function coefficient
+      real        :: T0          ! Reference temperature for NEBT
       real        :: NeHomog(MaxCloudType) ! Homogeneity noise
       real        :: NeCoreg(MaxCloudType) ! Coregistration noise
       real        :: NEBT        ! Noise equivalent brightness temperature

--- a/tools/pyorac/definitions.py
+++ b/tools/pyorac/definitions.py
@@ -533,12 +533,62 @@ class ParticleType:
     wvl - Wavelengths used (negative implies the second view)
     sad - SAD file directory to use
     ls  - If true, process land and sea separately
+    mb  - 'm' for monochromatic calculation or 'b' for band calculation
+           weighted by the spectral response function
+    atmospheric_model - code denoting the atmospheric model where
+                         00: cloud, no Rayleigh scattering
+                         01: cloud, includes Rayleigh scattering
+                         1X: aerosol, where X denotes the gaseous model where
+                                1 = Tropical Atmosphere
+                                2 = Midlatitude Summer
+                                3 = Midlatitude Winter
+                                4 = Subarctic Summer
+                                5 = Subarctic Winter
+                                6 = 1976 US Standard
+    microphysical_model - Three digit code to represent particle microphysics.
+                          Backwards compatible with old LUT naming
+                          e.g. a70 for aerosol dust model
+    version - LUT version
     """
 
-    def __init__(self, name, inv=(), sad="CCI_A70-A79"):
+    def __init__(self, name, inv=(),
+                 sad="CCI_A70-A79",
+                 mb='m',
+                 atmospheric_model='01',
+                 microphysical_model='old',
+                 version='06'):
         self.name = name
         self.inv = inv
         self.sad = sad
+        self.mb = mb
+        self.atmospheric_model = atmospheric_model
+        self.microphysical_model = microphysical_model
+        self.version = version
+
+    def sad_filename(self, inst):
+        """Return the filename of the SAD files."""
+        if self.sad == 'netcdf':
+            platform_name = inst.platform.lower()
+            sensor_name = inst.sensor.lower()
+            if sensor_name == 'seviri':
+                if platform_name == 'msg1':
+                    platform_name = 'meteosat-8'
+                if platform_name == 'msg2':
+                    platform_name = 'meteosat-9'
+                if platform_name == 'msg3':
+                    platform_name = 'meteosat-10'
+                if platform_name == 'msg4':
+                    platform_name = 'meteosat-11'
+            file_name = '_'.join((platform_name,
+                                  sensor_name,
+                                  self.mb,
+                                  self.name,
+                                  'a' + self.atmospheric_model,
+                                  'p' + self.microphysical_model,
+                                  'v' + self.version + '.nc'))
+        else:
+            file_name = "_".join((inst.inst, self.name, "RBD", "Ch*.sad"))
+        return file_name
 
     def sad_dir(self, sad_dirs, inst):
         """Return the path to the SAD files."""
@@ -549,11 +599,16 @@ class ParticleType:
             if "AVHRR" in inst.sensor:
                 fdr_name = join(fdr, inst.sensor.lower() + "-" +
                                 inst.noaa + "_" + self.sad)
-            if len(self.name) == 3:
-                file_name = "_".join((inst.inst, self.name, "RBD", "Ch*.sad"))
             else:
-                file_name = "_".join((inst.platform.lower(), inst.sensor.lower(),
-                                      self.name + ".nc"))
+                # Folder structure on JASMIN
+                # fdr_name = join(fdr, inst.sensor.lower() + "_" + self.sad)
+
+                # Folder structure on local
+                fdr_name = join(fdr, inst.sensor.lower() + "/" +
+                                inst.platform.upper() + "/" + self.sad)
+
+            # Determine SAD file name
+            file_name = self.sad_filename(inst)
 
             # SAD files stored in subdirectories
             if glob(join(fdr_name, file_name)):
@@ -570,6 +625,12 @@ class ParticleType:
 SETTINGS = {}
 SETTINGS['WAT'] = ParticleType("WAT", sad="WAT")
 SETTINGS['ICE'] = ParticleType("ICE", sad="ICE_baum")
+
+# Uncomment to use new netcdf LUTs
+SETTINGS['WAT'] = ParticleType("liquid-water", sad='netcdf')
+SETTINGS['ICE'] = ParticleType("water-ice", sad='netcdf',
+                               microphysical_model='agg')
+
 
 tau = Invpar('ITau', ap=-1.0, sx=1.5)
 SETTINGS['A70'] = ParticleType("A70", inv=(tau, Invpar('IRe', ap=0.0856, sx=0.15)))


### PR DESCRIPTION
This PR essentially fixes a few bugs in the netcdf LUT reader and adds functionality for varying NEBT/NEFR uncertainty with the measurements. The following should also be noted:

1. Homog and Coreg are not provided in the newluts and so are hard-coded when newluts are selected - this is a step toward separating forward model uncertainty and measurement uncertainty. When using the old LUTs they are read in from the SAD files as before.
2. Gains are currently hard-coded (see L177-L181 in `get_measurements.F90`). The gains should be read in from the level 1 headers, but this requires some discussion before implementing. 
3. Don's new approximation for `F0` variation is used when using newluts because `F1` is not supplied in the newluts for solar channels (this is done in `read_msi.F90`).
4. I have not added the ability to select old LUT sad values from new LUT netcdfs, but we can do this for backward compatibility. 
5. Bug in `locate.F90` is not fixed in this PR, but will be taken care of when we merge to master as Adam has already fixed it on master.
