### PR TITLE
Add string trimming for HDF-EOS library calls

### DIFF
--- a/pre_processing/read_ecmwf_nc.F90
+++ b/pre_processing/read_ecmwf_nc.F90
@@ -211,13 +211,13 @@ subroutine read_ecmwf_nc(nwp_path, ecmwf, preproc_dims, preproc_geoloc, &
       case('SD', 'sd')
          three_d = .false.
          array2d => preproc_prtm%snow_depth
-      case('U10', 'u10')
+      case('U10', 'u10', 'U10M')
          three_d = .false.
          array2d => preproc_prtm%u10
-      case('V10', 'v10')
+      case('V10', 'v10', 'V10M')
          three_d = .false.
          array2d => preproc_prtm%v10
-      case('T2', 't2')
+      case('T2', 't2', 'T2M')
          three_d = .false.
          array2d => preproc_prtm%temp2
       case('SKT', 'skt')

--- a/pre_processing/read_ecmwf_wind_nc.F90
+++ b/pre_processing/read_ecmwf_wind_nc.F90
@@ -161,7 +161,7 @@ subroutine read_ecmwf_wind_nc_file(nwp_path, ecmwf)
             allocate(ecmwf%lat(ecmwf%ydim))
             call ncdf_read_array(fid, name, ecmwf%lat)
          end if
-      case('U10', 'u10')
+      case('U10', 'u10', 'U10M')
          if (.not.associated(ecmwf%u10)) then
             allocate(ecmwf%u10(ecmwf%xdim,ecmwf%ydim))
             allocate(val(ecmwf%xdim,ecmwf%ydim,1,1))
@@ -169,7 +169,7 @@ subroutine read_ecmwf_wind_nc_file(nwp_path, ecmwf)
             ecmwf%u10 = val(:,:,1,1)
             deallocate(val)
          end if
-      case('V10', 'v10')
+      case('V10', 'v10', 'V10M')
          if (.not.associated(ecmwf%v10)) then
             allocate(ecmwf%v10(ecmwf%xdim,ecmwf%ydim))
             allocate(val(ecmwf%xdim,ecmwf%ydim,1,1))

--- a/pre_processing/read_mcd43c1.F90
+++ b/pre_processing/read_mcd43c1.F90
@@ -122,7 +122,7 @@ subroutine read_mcd43c1(path_to_file, mcd, nbands, bands, read_params, &
    ! We'll need it's name to "attach" to it and extract the data
    if (verbose) write(*,*) 'Reading: ', trim(path_to_file)
    stat = 0
-   stat = gdinqgrid(path_to_file, gridlist, gridlistlen)
+   stat = gdinqgrid(trim(adjustl(path_to_file)), gridlist, gridlistlen)
    if (stat .ne. 1) then
       write(*,*) 'ERROR: read_mcd43c1(), problem with gdinqgrid(): ', stat
       stop error_stop_code
@@ -132,9 +132,9 @@ subroutine read_mcd43c1(path_to_file, mcd, nbands, bands, read_params, &
 
    ! Open the datafile and get a file descriptor, and then attach to the grid
    ! (using the name returned above)
-   fid = gdopen(path_to_file, DFACC_READ)
+   fid = gdopen(trim(adjustl(path_to_file)), DFACC_READ)
 
-   gid = gdattach(fid, trim(gridlist))
+   gid = gdattach(fid, trim(adjustl(gridlist)))
 
    if (verbose) write(*,*) 'File and grid IDs are: ', fid, gid
 
@@ -237,7 +237,7 @@ subroutine read_mcd43c1(path_to_file, mcd, nbands, bands, read_params, &
          dataname = 'BRDF_Albedo_Parameter1_' // trim(BandList(bands(i)))
 
          if (verbose) write(*,*) 'Reading parameter: ', trim(dataname)
-         stat = gdrdfld(gid, trim(dataname), start, stride, edge, tmpdata)
+         stat = gdrdfld(gid, trim(adjustl(dataname)), start, stride, edge, tmpdata)
          if (stat .ne. 0) then
             write(*,*) 'ERROR: read_mcd43c1(), gdrdfld(): ', stat
             stop error_stop_code
@@ -275,7 +275,7 @@ subroutine read_mcd43c1(path_to_file, mcd, nbands, bands, read_params, &
          dataname = 'BRDF_Albedo_Parameter2_' // trim(BandList(bands(i)))
 
          if (verbose) write(*,*) 'Reading parameter: ', trim(dataname)
-         stat = gdrdfld(gid, trim(dataname), start, stride, edge, tmpdata)
+         stat = gdrdfld(gid, trim(adjustl(dataname)), start, stride, edge, tmpdata)
          if (stat .ne. 0) then
             write(*,*) 'ERROR: read_mcd43c1(), gdrdfld(): ', stat
             stop error_stop_code
@@ -298,7 +298,7 @@ subroutine read_mcd43c1(path_to_file, mcd, nbands, bands, read_params, &
          dataname = 'BRDF_Albedo_Parameter3_' // trim(BandList(bands(i)))
 
          if (verbose) write(*,*) 'Reading parameter: ', trim(dataname)
-         stat = gdrdfld(gid, trim(dataname), start, stride, edge, tmpdata)
+         stat = gdrdfld(gid, trim(adjustl(dataname)), start, stride, edge, tmpdata)
          if (stat .ne. 0) then
             write(*,*) 'ERROR: read_mcd43c1(), gdrdfld(): ', stat
             stop error_stop_code

--- a/pre_processing/read_mcd43c3.F90
+++ b/pre_processing/read_mcd43c3.F90
@@ -131,7 +131,7 @@ subroutine read_mcd43c3(path_to_file, mcd, nbands, bands, read_ws, read_bs, &
    ! We'll need it's name to "attach" to it and extract the data
    if (verbose) write(*,*) 'Reading: ', trim(path_to_file)
    stat = 0
-   stat = gdinqgrid(path_to_file, gridlist, gridlistlen)
+   stat = gdinqgrid(trim(adjustl(path_to_file)), gridlist, gridlistlen)
    if (stat .ne. 1) then
       write(*,*) 'ERROR: read_mcd43c3(), problem with gdinqgrid(): ', stat
       stop error_stop_code
@@ -143,7 +143,7 @@ subroutine read_mcd43c3(path_to_file, mcd, nbands, bands, read_ws, read_bs, &
    ! (using the name returned above)
    fid = gdopen(path_to_file, DFACC_READ)
 
-   gid = gdattach(fid, trim(gridlist))
+   gid = gdattach(fid, trim(adjustl(gridlist)))
 
    if (verbose) write(*,*) 'File and grid IDs are: ', fid, gid
 
@@ -259,7 +259,7 @@ subroutine read_mcd43c3(path_to_file, mcd, nbands, bands, read_ws, read_bs, &
          dataname = 'Albedo_WSA_' // trim(BandList(bands(i)))
 
          if (verbose) write(*,*) 'Reading variable: ', trim(dataname)
-         stat = gdrdfld(gid, trim(dataname), start, stride, edge, tmpdata)
+         stat = gdrdfld(gid, trim(adjustl(dataname)), start, stride, edge, tmpdata)
          if (stat .ne. 0) then
             write(*,*) 'ERROR: read_mcd43c3(), gdrdfld(): ', stat
             stop error_stop_code
@@ -292,7 +292,7 @@ subroutine read_mcd43c3(path_to_file, mcd, nbands, bands, read_ws, read_bs, &
          dataname = 'Albedo_BSA_' // trim(BandList(bands(i)))
 
          write(*,*) 'Reading parameter: ', dataname
-         stat = gdrdfld(gid, dataname, start, stride, edge, tmpdata)
+         stat = gdrdfld(gid, trim(adjustl(dataname)), start, stride, edge, tmpdata)
          if (stat .ne. 0) then
             write(*,*) 'ERROR: read_mcd43c3(), gdrdfld(): ', stat
             stop error_stop_code


### PR DESCRIPTION
When compiling ORAC and its dependecies with gfortran 4.8.5 on the DWD servers I got an segmentation fault in the `read_mcdc43X.F90` files where strings are passed to external functions in the HDF-EOS library. Trimming those strings with `trim(adjustl())` solved this issue.

I also reintroduced `U10M`, `V10M`, `T2M` variables to  ERA5 variable names in the `read_ecmwf_nc.F90` and `read_ecmwf_wind_nc.F90` as the DWD ERA5 files contain those. 