### PR TITLE
Fix ncdf

### DIFF
--- a/common/ncdf_read_field.inc
+++ b/common/ncdf_read_field.inc
@@ -38,17 +38,30 @@
 
    ! replace file's fill value and out of range values with our own and apply
    ! scale factor/offset
-   if (.not. fv_flag) fv = fill
-   if (vr_flag) then
-      where (arr.ne.fv .and. arr.lt.vmin) arr = fv
-      where (arr.ne.fv .and. arr.gt.vmax) arr = fv
-   end if
-   if (sf .ne. 1.0 .or. of .ne. 0.0) then
-      where (arr.ne.fv)
-        arr = sf*arr + of
-      elsewhere
-        arr = fill
-      endwhere
+   if (fv_flag) then
+      if (vr_flag) then
+         where (arr.ne.fv .and. arr.lt.vmin) arr = fv
+         where (arr.ne.fv .and. arr.gt.vmax) arr = fv
+      end if
+      if (sf .ne. 1.0 .or. of .ne. 0.0) then
+         where (arr.ne.fv)
+            arr = sf*arr + of
+         elsewhere
+            arr = fill
+         endwhere
+      end if
+   else
+      if (sf .ne. 1.0 .or. of .ne. 0.0) then
+         if (vr_flag) then
+            where(arr.ge.vmin .and. arr.le.vmax)
+               arr = sf*arr + of
+            elsewhere
+               arr = fill
+            endwhere
+         else
+            arr = sf*arr + of
+         end if
+      end if
    end if
 
    ! additional information for print out

--- a/common/ncdf_read_field.inc
+++ b/common/ncdf_read_field.inc
@@ -38,6 +38,7 @@
 
    ! replace file's fill value and out of range values with our own and apply
    ! scale factor/offset
+   if (.not. fv_flag) fv = fill
    if (vr_flag) then
       where (arr.ne.fv .and. arr.lt.vmin) arr = fv
       where (arr.ne.fv .and. arr.gt.vmax) arr = fv

--- a/common/ncdf_read_field.inc
+++ b/common/ncdf_read_field.inc
@@ -38,14 +38,16 @@
 
    ! replace file's fill value and out of range values with our own and apply
    ! scale factor/offset
-   if (fv_flag) &
-      where (arr.eq.fv) arr = fill
    if (vr_flag) then
-      where (arr.ne.fill .and. arr.lt.vmin) arr = fill
-      where (arr.ne.fill .and. arr.gt.vmax) arr = fill
+      where (arr.ne.fv .and. arr.lt.vmin) arr = fv
+      where (arr.ne.fv .and. arr.gt.vmax) arr = fv
    end if
    if (sf .ne. 1.0 .or. of .ne. 0.0) then
-      where (arr.ne.fill) arr = sf*arr + of
+      where (arr.ne.fv)
+        arr = sf*arr + of
+      elsewhere
+        arr = fill
+      endwhere
    end if
 
    ! additional information for print out


### PR DESCRIPTION
ORAC reads netcdf files by first applying a fill value (`-999`) and then applying the scale + offset specified in the netcdf attributes.
This is problematic in the case that `-999` is a valid value in the unscaled netCDF data (such as for short int data in the range `-32766` -> `+32767`).

In this PR I correct the netcdf read code so that this problem doesn't arise any more. I think I also have it set up to cover the case that the input netcdf data doesn't contain a fill value but can't actually check this as I don't have any such netcdf files available.