### PR TITLE
RTTOV Updates

### DIFF
--- a/common/ncdf_read_field.inc
+++ b/common/ncdf_read_field.inc
@@ -38,6 +38,7 @@
 
    ! replace file's fill value and out of range values with our own and apply
    ! scale factor/offset
+   if (.not. fv_flag) fv = fill
    if (vr_flag) then
       where (arr.ne.fv .and. arr.lt.vmin) arr = fv
       where (arr.ne.fv .and. arr.gt.vmax) arr = fv

--- a/common/ncdf_read_field.inc
+++ b/common/ncdf_read_field.inc
@@ -38,14 +38,16 @@
 
    ! replace file's fill value and out of range values with our own and apply
    ! scale factor/offset
-   if (fv_flag) &
-      where (arr.eq.fv) arr = fill
    if (vr_flag) then
-      where (arr.ne.fill .and. arr.lt.vmin) arr = fill
-      where (arr.ne.fill .and. arr.gt.vmax) arr = fill
+      where (arr.ne.fv .and. arr.lt.vmin) arr = fv
+      where (arr.ne.fv .and. arr.gt.vmax) arr = fv
    end if
    if (sf .ne. 1.0 .or. of .ne. 0.0) then
-      where (arr.ne.fill) arr = sf*arr + of
+      where (arr.ne.fv)
+        arr = sf*arr + of
+      elsewhere
+        arr = fill
+      endwhere
    end if
 
    ! additional information for print out


### PR DESCRIPTION
RTTOV v13.1 has now been released. This version incorporates quite a few bugfixes and also enables users to disable radiance calculations (thus only performing the transmittance calculations). In ORAC, we only use transmittance for the VIS channels so can take advantage of this RTTOV update to ignore radiance.
In addition, we should remove the Rayleigh calculations from our code, as this can now be disabled within RTTOV rather than our having to remove them ourselves.

This PR is a placeholder for doing the above, which I will update as I progress.