### PR TITLE
Updates to ancillary data readers

### DIFF
--- a/pre_processing/ocean_colour.F90
+++ b/pre_processing/ocean_colour.F90
@@ -430,7 +430,7 @@ subroutine get_ocean_colour(cyear, cmonth, occci_path, lat, lon, &
    ! Check that our data is within the OceanColour_cci data record
    if ((iyear .lt. 1997) .or. &
        ((iyear .eq. 1997) .and. (imonth .lt. 9)) .or. &
-       (iyear .gt. 2013)) then
+       (iyear .gt. 2020)) then
       cyear2 = 'XXXX'
    else
       cyear2 = cyear
@@ -441,10 +441,7 @@ subroutine get_ocean_colour(cyear, cmonth, occci_path, lat, lon, &
       occci_path_file = occci_path
    else
       occci_path_full = trim(adjustl(occci_path))//'/'//trim(adjustl(cyear2))
-      occci_file_regex = 'ESACCI-OC-L3S-IOP-MERGED-1M_MONTHLY_4km_GEO_..._OC.v._QAA-'// &
-           trim(adjustl(cyear2))//trim(adjustl(cmonth))//'-fv.\..\.nc'
-
-      occci_file_regex = 'ESACCI-OC-L3S-OC_PRODUCTS-MERGED-1M_MONTHLY_4km_GEO_..._OC._QAA-'// &
+      occci_file_regex = 'ESACCI-OC-L3S-IOP-MERGED-1M_MONTHLY_4km_GEO_..._OCx_QAA-'// &
            trim(adjustl(cyear2))//trim(adjustl(cmonth))//'-fv.\..\.nc'
       if (match_file(trim(occci_path_full), trim(occci_file_regex), occci_file) .ne. 0) then
          occci_file_regex = 'ESACCI-OC-L3S-OC_PRODUCTS-MERGED-1M_MONTHLY_4km_GEO_..._OC._QAA-'//&

--- a/pre_processing/ocean_colour.F90
+++ b/pre_processing/ocean_colour.F90
@@ -100,7 +100,7 @@ end subroutine deallocate_occci
 ! - if the requested wavelength is less than the lowest OCCCI wavelength
 !   (412 nm), the lowest two wavelength bands will be returned.
 ! - if the requested wavelength is larger then the highest OCCCI wavelength
-!   (670 nm), the highest two wavelength bands will be returned.
+!   (665 nm), the highest two wavelength bands will be returned.
 ! - For bandss between these two extremes, the pair of bands the bracket the
 !   requested wavelength will be choosen.
 ! The required OCCCI bands are marked for reading with a boolean flag, and the
@@ -145,12 +145,12 @@ function read_oceancolour_cci(path_to_file, occci, wavelengths, verbose) &
    ! Local variables
    integer,          parameter :: occci_nwl = 6
    real(kind=sreal), parameter :: occci_wl(occci_nwl) = &
-        (/ 0.412, 0.443, 0.490, 0.510, 0.555, 0.670 /)
+        (/ 0.412, 0.443, 0.490, 0.510, 0.560, 0.665 /)
    character(len=8), parameter :: occci_atotvar(occci_nwl) = &
         (/ 'atot_412', 'atot_443', 'atot_490', 'atot_510', &
-           'atot_555', 'atot_670' /)
+           'atot_560', 'atot_665' /)
    character(len=7), parameter :: occci_bbpvar(occci_nwl) = &
-        (/ 'bbp_412', 'bbp_443', 'bbp_490', 'bbp_510', 'bbp_555', 'bbp_670' /)
+        (/ 'bbp_412', 'bbp_443', 'bbp_490', 'bbp_510', 'bbp_560', 'bbp_665' /)
 
    integer                       :: i, j
    integer                       :: nwl
@@ -179,7 +179,7 @@ function read_oceancolour_cci(path_to_file, occci, wavelengths, verbose) &
    call ncdf_open(fid, path_to_file, 'read_oceancolour_cci()')
 
    ! Variables needed: atot (total absorption), bbp (particulate backscatter)
-   ! Available wavelengths: 412, 443, 490, 510, 555, 670 nm.
+   ! Available wavelengths: 412, 443, 490, 510, 560, 665 nm.
    if (verbose) write(*,*) 'Extracting dimension IDs'
    ! Extract the array dimensions
    ntime = ncdf_dim_length(fid, 'time', 'read_oceancolour_cci()')

--- a/pre_processing/select_camel_emiss_file.F90
+++ b/pre_processing/select_camel_emiss_file.F90
@@ -38,7 +38,7 @@ subroutine select_camel_emiss_file(cyear, cmonth, camel_emis_path, &
    camel_emis_path_file = trim(adjustl(camel_emis_path))// &
       '/CAM5K30EM_emis_'// &
       trim(adjustl(cyear))// &
-      trim(adjustl(cmonth))//'_V001.nc'
+      trim(adjustl(cmonth))//'_V002.nc'
 
    ! Check that the defined file exists and is readable
    inquire(file=trim(camel_emis_path_file), exist=camel_emis_file_exist, &
@@ -47,7 +47,7 @@ subroutine select_camel_emiss_file(cyear, cmonth, camel_emis_path, &
       camel_emis_path_file = trim(adjustl(camel_emis_path))// &
       '/CAM5K30EM_emis_'// &
       trim(adjustl(cyear))// &
-      trim(adjustl(cmonth))//'_V002.nc'
+      trim(adjustl(cmonth))//'_V001.nc'
        inquire(file=trim(camel_emis_path_file), exist=camel_emis_file_exist, &
           read=camel_emis_file_read)
        if (.not.camel_emis_file_exist) then

--- a/pre_processing/select_camel_emiss_file.F90
+++ b/pre_processing/select_camel_emiss_file.F90
@@ -56,7 +56,8 @@ subroutine select_camel_emiss_file(cyear, cmonth, camel_emis_path, &
                      trim(camel_emis_path_file)
           stop error_stop_code
        endif
-   else if (trim(camel_emis_file_read).eq.'NO') then
+   endif
+   if (trim(camel_emis_file_read).eq.'NO') then
       write(*,*) 'ERROR: select_camel_emiss_file(): camel surface ' // &
                  'emissivity file exists but is not readable, filename: ', &
                  trim(camel_emis_path_file)

--- a/pre_processing/select_camel_emiss_file.F90
+++ b/pre_processing/select_camel_emiss_file.F90
@@ -44,10 +44,18 @@ subroutine select_camel_emiss_file(cyear, cmonth, camel_emis_path, &
    inquire(file=trim(camel_emis_path_file), exist=camel_emis_file_exist, &
       read=camel_emis_file_read)
    if (.not.camel_emis_file_exist) then
-      write(*,*) 'ERROR: select_camel_emiss_file(): camel surface ' // &
-                 'emissivity file does not exist, filename: ', &
-                 trim(camel_emis_path_file)
-      stop error_stop_code
+      camel_emis_path_file = trim(adjustl(camel_emis_path))// &
+      '/CAM5K30EM_emis_'// &
+      trim(adjustl(cyear))// &
+      trim(adjustl(cmonth))//'_V002.nc'
+       inquire(file=trim(camel_emis_path_file), exist=camel_emis_file_exist, &
+          read=camel_emis_file_read)
+       if (.not.camel_emis_file_exist) then
+          write(*,*) 'ERROR: select_camel_emiss_file(): camel surface ' // &
+                     'emissivity file does not exist, filename: ', &
+                     trim(camel_emis_path_file)
+          stop error_stop_code
+       endif
    else if (trim(camel_emis_file_read).eq.'NO') then
       write(*,*) 'ERROR: select_camel_emiss_file(): camel surface ' // &
                  'emissivity file exists but is not readable, filename: ', &


### PR DESCRIPTION
The ocean colour and CAMEL readers are only working for old formats of data. This update makes them work with new versions. Ocean colour must now be a recent version (tested with v5.0, may work with v4.0) but camel can handle either V1 or V2 data.