### PR TITLE
Update ORAC main processor to enable customised filenames for output

### DIFF
--- a/pre_processing/read_himawari.F90
+++ b/pre_processing/read_himawari.F90
@@ -316,6 +316,7 @@ subroutine read_himawari_bin(infile, imager_geolocation, imager_measurements, &
                      .false., & ! True = output as VIS channel resolution, False = Output at IR res .
                      global_atts%Satpos_Metadata, & ! Struct to store the satellite position data, for parallax
                      .true., & ! Compute or not the solar angles in the reader.
+                     .true., & ! Use updated (block 6, true) or original (block 5, false) VIS calibration
                      verbose) .ne. 0) then ! Verbosity flag.
       write(*,*) 'ERROR: in read_himawari_read(), calling ' // &
                  'AHI_Main_Read(), filename = ', trim(infile)

--- a/src/ctrl.F90
+++ b/src/ctrl.F90
@@ -136,6 +136,7 @@ module Ctrl_m
       character(FilenameLen) :: Alb                ! Surface albedo, emissivity
       character(FilenameLen) :: L2_primary         ! Primary output file
       character(FilenameLen) :: L2_secondary       ! Secondary output file
+      character(FilenameLen) :: L2_comment         ! Additional text for output filename
    end type FID_t
 
    ! Indices: channel indexing and spatial grid definitions

--- a/src/read_driver.F90
+++ b/src/read_driver.F90
@@ -451,7 +451,7 @@ subroutine Read_Driver(Ctrl, global_atts, source_atts)
 
    ! Output filenames
    outname = trim(Ctrl%FID%Out_Dir)//'/'//trim(Ctrl%FID%Filename)// &
-            trim(Ctrl%LUTClassLayers)
+            trim(Ctrl%LUTClassLayers)//'_'//trim(Ctrl%FID%L2_comment)
    Ctrl%FID%L2_primary   = trim(outname)//'.primary.nc'
    Ctrl%FID%L2_secondary = trim(outname)//'.secondary.nc'
 


### PR DESCRIPTION
This is primarily a kicking-off point for discussion on how to incorprorate custom file naming into the ORAC main processor.
The issue we have is that currently the filename is decided from the input filename (from the preprocessor) and the LUT class. With the new ORAC LUTs we now have multiple LUT types for the same class (for example, various ice habits) and each of these would produce the same output filename - which is undesirable.
A workaround is to save each LUT output to its own directory but that seems very messy.
Here, I add a variable to the main processor that allows the user to set a 'comment' in their driver file that then gets used in the ORAC filenames. For example, when processing the general habit mixture for ICE I can set:
`Ctrl%FID%L2_comment         = AGG` and the output filename will end with `_AGG.primary.nc`.

This gets around the issue but might not be the best solution. Let's discuss what we should do.
Options I can think of.
1) Keep the status quo. Works with all our existing code but presents problems with multiple LUTs.
2) Add an attribute inside each LUT that adds a LUT specific 'comment' to the filename. This is less flexible but also less likely to break other parts of the code.
3) This approach. Very flexible, but could break the python scripts and post-processor.