### PR TITLE
Update MODIS Albedo/Parameter code to take quality flags into account.

### DIFF
--- a/pre_processing/get_surface_reflectance.F90
+++ b/pre_processing/get_surface_reflectance.F90
@@ -120,7 +120,8 @@
 subroutine get_surface_reflectance(cyear, cdoy, cmonth, modis_surf_path, &
      modis_brdf_path, occci_path, imager_flags, imager_geolocation, &
      imager_angles, channel_info, ecmwf, assume_full_path, include_full_brdf, &
-     use_occci, use_swansea_climatology, swan_g, verbose, surface, source_atts)
+     use_occci, use_swansea_climatology, swan_g, verbose, mcd43_maxqa, &
+     surface, source_atts)
 
    use channel_structures_m
    use cox_munk_m
@@ -158,6 +159,7 @@ subroutine get_surface_reflectance(cyear, cdoy, cmonth, modis_surf_path, &
    logical,                    intent(in)    :: use_swansea_climatology
    real,                       intent(in)    :: swan_g
    logical,                    intent(in)    :: verbose
+   integer,                    intent(in)    :: mcd43_maxqa
    type(surface_t),            intent(inout) :: surface
    type(source_attributes_t),  intent(inout) :: source_atts
 
@@ -407,11 +409,11 @@ subroutine get_surface_reflectance(cyear, cdoy, cmonth, modis_surf_path, &
               mcdc3)
       else
          call read_mcd43c3(modis_surf_path_file, mcdc3, n_bands, bands, &
-              .true., .false., .false., verbose, stat)
+              .true., .false., .true., mcd43_maxqa, verbose, stat)
 
          if (include_full_brdf) then
             call read_mcd43c1(modis_brdf_path_file, mcdc1, n_bands, bands, &
-                 .true., .false., verbose, stat)
+                 .true., .true., mcd43_maxqa, verbose, stat)
          end if
       end if
 

--- a/pre_processing/orac_preproc.F90
+++ b/pre_processing/orac_preproc.F90
@@ -494,6 +494,7 @@ subroutine orac_preproc(mytask, ntasks, lower_bound, upper_bound, driver_path_fi
    preproc_opts%do_co2                   = .true.
    preproc_opts%use_swansea_climatology  = .false.
    preproc_opts%swansea_gamma            = 0.3
+   preproc_opts%mcd43_max_qaflag         = 5
 
    ! When true, the offset between the nadir and oblique views is read from
    ! the track_offset global attribute. Otherwise, the two longitude fields are
@@ -947,7 +948,7 @@ subroutine orac_preproc(mytask, ntasks, lower_bound, upper_bound, driver_path_fi
               imager_geolocation, imager_angles, channel_info, ecmwf, &
               assume_full_paths, include_full_brdf, preproc_opts%use_occci, &
               preproc_opts%use_swansea_climatology, preproc_opts%swansea_gamma, verbose, &
-              surface, source_atts)
+              preproc_opts%mcd43_max_qaflag, surface, source_atts)
 
          ! Use the Near-real-time Ice and Snow Extent (NISE) data from the National
          ! Snow and Ice Data Center to detect ice and snow pixels, and correct the

--- a/pre_processing/preproc_structures.F90
+++ b/pre_processing/preproc_structures.F90
@@ -120,6 +120,7 @@ module preproc_structures_m
       logical                    :: use_predef_geo
       logical                    :: use_predef_lsm
       logical                    :: use_swansea_climatology
+      integer                    :: mcd43_max_qaflag
       
       character(len=path_length) :: ext_lsm_path
       character(len=path_length) :: ext_geo_path

--- a/pre_processing/read_mcd43c1.F90
+++ b/pre_processing/read_mcd43c1.F90
@@ -317,6 +317,8 @@ subroutine read_mcd43c1(path_to_file, mcd, nbands, bands, read_params, &
                end if
             end do
          end do
+         
+         ! Apply QA filtering if desired. Pixels with QA worse than threshold are set to fill
          if (read_QC) then
            where (mcd%quality .gt. mcd43_maxqa) mcd%brdf_albedo_params(:,:,1,i) = sreal_fill_value
            where (mcd%quality .gt. mcd43_maxqa) mcd%brdf_albedo_params(:,:,2,i) = sreal_fill_value

--- a/pre_processing/read_mcd43c1.F90
+++ b/pre_processing/read_mcd43c1.F90
@@ -32,7 +32,7 @@
 !-------------------------------------------------------------------------------
 
 subroutine read_mcd43c1(path_to_file, mcd, nbands, bands, read_params, &
-                        read_QC, verbose, stat)
+                        read_QC, mcd43_maxqa, verbose, stat)
 
    use preproc_constants_m
 
@@ -46,6 +46,7 @@ subroutine read_mcd43c1(path_to_file, mcd, nbands, bands, read_params, &
    integer,          intent(in) :: bands(:)
    logical,          intent(in) :: read_params
    logical,          intent(in) :: read_QC
+   integer,          intent(in) :: mcd43_maxqa
    logical,          intent(in) :: verbose
 
    ! Output variables
@@ -220,7 +221,7 @@ subroutine read_mcd43c1(path_to_file, mcd, nbands, bands, read_params, &
       allocate(mcd%percent_snow(1,1))
       allocate(mcd%percent_inputs(1,1))
 
-      mcd%quality(1,1) = 127
+      mcd%quality(1,1) = 0
       mcd%local_solar_noon(1,1) = 127
       mcd%percent_snow(1,1) = 127
       mcd%percent_inputs(1,1) = 127
@@ -316,9 +317,12 @@ subroutine read_mcd43c1(path_to_file, mcd, nbands, bands, read_params, &
                end if
             end do
          end do
-
+         if (read_QC) then
+           where (mcd%quality .gt. mcd43_maxqa) mcd%brdf_albedo_params(:,:,1,i) = sreal_fill_value
+           where (mcd%quality .gt. mcd43_maxqa) mcd%brdf_albedo_params(:,:,2,i) = sreal_fill_value
+           where (mcd%quality .gt. mcd43_maxqa) mcd%brdf_albedo_params(:,:,3,i) = sreal_fill_value
+         endif
       end do
-
 
       deallocate(tmpdata)
    else

--- a/pre_processing/read_mcd43c3.F90
+++ b/pre_processing/read_mcd43c3.F90
@@ -40,7 +40,7 @@
 !-------------------------------------------------------------------------------
 
 subroutine read_mcd43c3(path_to_file, mcd, nbands, bands, read_ws, read_bs, &
-                        read_QC, verbose, stat)
+                        read_QC, mcd43_maxqa, verbose, stat)
 
    use preproc_constants_m
 
@@ -55,6 +55,7 @@ subroutine read_mcd43c3(path_to_file, mcd, nbands, bands, read_ws, read_bs, &
    logical,          intent(in) :: read_ws
    logical,          intent(in) :: read_bs
    logical,          intent(in) :: read_QC
+   integer,          intent(in) :: mcd43_maxqa
    logical,          intent(in) :: verbose
 
    ! Output variables
@@ -229,7 +230,7 @@ subroutine read_mcd43c3(path_to_file, mcd, nbands, bands, read_ws, read_bs, &
       allocate(mcd%percent_snow(1,1))
       allocate(mcd%percent_inputs(1,1))
 
-      mcd%quality(1,1) = 127
+      mcd%quality(1,1) = 0
       mcd%local_solar_noon(1,1) = 127
       mcd%percent_snow(1,1) = 127
       mcd%percent_inputs(1,1) = 127
@@ -284,7 +285,9 @@ subroutine read_mcd43c3(path_to_file, mcd, nbands, bands, read_ws, read_bs, &
                end if
             end do
          end do
-
+         if (read_QC) then
+           where (mcd%quality .gt. mcd43_maxqa) mcd%WSA(:,:,i) = sreal_fill_value
+         endif
       end if
 
       ! Read the black sky albedo
@@ -317,7 +320,9 @@ subroutine read_mcd43c3(path_to_file, mcd, nbands, bands, read_ws, read_bs, &
                end if
             end do
          end do
-
+         if (read_QC) then
+           where (mcd%quality .gt. mcd43_maxqa) mcd%WSA(:,:,i) = sreal_fill_value
+         endif
       end if
    end do
 

--- a/pre_processing/read_mcd43c3.F90
+++ b/pre_processing/read_mcd43c3.F90
@@ -285,6 +285,8 @@ subroutine read_mcd43c3(path_to_file, mcd, nbands, bands, read_ws, read_bs, &
                end if
             end do
          end do
+         
+         ! Apply QA filtering if desired. Pixels with QA worse than threshold are set to fill
          if (read_QC) then
            where (mcd%quality .gt. mcd43_maxqa) mcd%WSA(:,:,i) = sreal_fill_value
          endif
@@ -320,6 +322,8 @@ subroutine read_mcd43c3(path_to_file, mcd, nbands, bands, read_ws, read_bs, &
                end if
             end do
          end do
+         
+         ! Apply QA filtering if desired. Pixels with QA worse than threshold are set to fill
          if (read_QC) then
            where (mcd%quality .gt. mcd43_maxqa) mcd%WSA(:,:,i) = sreal_fill_value
          endif

--- a/pre_processing/utils_for_main.F90
+++ b/pre_processing/utils_for_main.F90
@@ -168,6 +168,9 @@ subroutine parse_optional(label, value, preproc_opts)
    case('CALCULATE_SLSTR_ALIGNMENT')
       if (parse_string(value, preproc_opts%calculate_slstr_alignment) /= 0) &
            call handle_parse_error(label)
+   case('MCD43_MAX_QAFLAG')
+      if (parse_string(value, preproc_opts%mcd43_max_qaflag) /= 0) &
+           call handle_parse_error(label)
    case default
       write(*,*) 'ERROR: Unknown option: ', trim(label)
       stop error_stop_code


### PR DESCRIPTION
Currently the MCD43 code in the pre processor doesn't take into account the quality flags that accompany the data. Indeed, we don't even read the QA flags.

This leads to issues when the MODIS BRDF cannot be inverted in the upstream code, as it will then fall back to a magnitude inversion or - in particularly bad cases - fill values. In this PR I update ORAC to read the QA flag and apply filtering if requested by the user. By default, no filtering is done (i.e: Behaviour remains same as now).
Users can set the desired QA threshold by passing `MCD43_MAX_QAFLAG=n` via the preprocessor driver file, where `n` is the desired maximum QA value.
QA values are defined as follows:
```
 - 0: best quality, 100% with full inversions
 - 1: good quality, 75% or more with best full inversions and 90% with full inversions
 - 2: relative good quality, 75% or more with full inversions
 - 3: mixed, 75% or less full inversions and 25% or less fill values
 - 4: all magnitude iversions or 50% or less fill values
 - 5: 50% or more fill values
 - 255: fill value
```

Setting `MCD43_MAX_QAFLAG` to `3` for example, will allow pixels with QA values of 0, 1, 2, or 3 to pass while those with values of 4, 5 or 255 will be set to the fill value.

Below is an example of how this can be used to filter bad quality retrievals, in this case cloud contamination in the BRDF magnitude inversion:
<img src="https://user-images.githubusercontent.com/13449576/144070871-88f06ce0-74b8-4b6f-a804-0ec50624597f.png" width=50% height=50%>
<img src="https://user-images.githubusercontent.com/13449576/144070893-9fe18785-c9e5-4d3a-a628-6732a0fbcee8.png" width=50% height=50%>
<img src="https://user-images.githubusercontent.com/13449576/144070883-11ad6235-2ae1-4faa-be8a-d94c484697ea.png" width=50% height=50%>

