### PR TITLE
Allow CTP to be set using an auxiliary file

### DIFF
--- a/src/ctrl.F90
+++ b/src/ctrl.F90
@@ -103,6 +103,7 @@
 ! 2017/10/04, GM: Add use_ann_phase.
 ! 2021/04/06, AP: New LUT names.
 ! 2021/10/12, ATP: Add new LUT netcdf filenames.
+! 2022/01/27, GT: Add prior CTP filename to FID structure.
 !
 ! Bugs:
 ! None known.
@@ -134,6 +135,7 @@ module Ctrl_m
       character(FilenameLen) :: Geo                ! Geometry (sun-satellite)
       character(FilenameLen) :: Loc                ! Location (latitudes/longs)
       character(FilenameLen) :: Alb                ! Surface albedo, emissivity
+      character(FilenameLen) :: CTP                ! A priori cloud-top pressure
       character(FilenameLen) :: L2_primary         ! Primary output file
       character(FilenameLen) :: L2_secondary       ! Secondary output file
    end type FID_t

--- a/src/data.F90
+++ b/src/data.F90
@@ -35,6 +35,8 @@
 ! 2016/04/28, AP: Add multiple views.
 ! 2017/06/21, OS: Added ANN phase variables.
 ! 2018/06/08, SP: Add satellite azimuth angle to output.
+! 2022/01/27, GT: Add State type, to hold a priori/first guess state parameters
+!    read from auxiliary files. So far, it only holds CTP.
 !
 ! Bugs:
 ! None known.
@@ -49,6 +51,7 @@ module Data_m
    public :: Geometry_t, &
              Location_t, &
              Scan_t, &
+             State_t, &
              Data_t, &
              Dealloc_Data, &
              Read_Data
@@ -64,6 +67,11 @@ module Data_m
       real, pointer :: Lat(:,:)
       real, pointer :: Lon(:,:)
    end type Location_t
+
+   type State_t
+      real, pointer :: CTP(:,:)
+      real, pointer :: CTP_var(:,:)
+   end type State_t
 
    type Data_t
       real,               pointer :: ALB(:,:,:)
@@ -81,6 +89,7 @@ module Data_m
       real,               pointer :: cphcot(:,:,:)
       type(Geometry_t)            :: Geometry
       type(Location_t)            :: Location
+      type(State_t)               :: State
       integer(byte),      pointer :: LSFlags(:,:)
       integer(byte),      pointer :: lusflags(:,:)
       integer(sint),      pointer :: dem(:,:)
@@ -116,6 +125,7 @@ contains
 #include "read_lsflags.F90"
 #include "read_location.F90"
 #include "read_msi.F90"
+#include "read_ctp.F90"
 
 #include "sabotage_inputs.F90"
 

--- a/src/dealloc_data.F90
+++ b/src/dealloc_data.F90
@@ -32,6 +32,7 @@
 ! 2015/04/28, AP: Added fields for surface uncertainty and correlation.
 ! 2017/06/21, OS: added ann phase variables
 ! 2018/06/08, SP: Add satellite azimuth angle to output.
+! 2022/01/27, GT: Added CTP prior data.
 !
 ! Bugs:
 ! None known.
@@ -94,5 +95,9 @@ subroutine Dealloc_Data(Ctrl, MSI_Data)
    if (associated(MSI_Data%snow_unc))     deallocate(MSI_Data%snow_unc)
 
    if (associated(MSI_Data%illum))        deallocate(MSI_Data%illum)
+
+   if (associated(MSI_Data%State%CTP))    deallocate(MSI_Data%State%CTP)
+   if (associated(MSI_Data%State%CTP_var)) &
+                                          deallocate(MSI_Data%State%CTP_var)
 
 end subroutine Dealloc_Data

--- a/src/dependencies.inc
+++ b/src/dependencies.inc
@@ -2,8 +2,9 @@ $(OBJS)/cholesky.o: invert_cholesky.F90 solve_cholesky.F90
 $(OBJS)/ctrl.o: $(OBJS)/orac_constants.o dealloc_ctrl.F90
 $(OBJS)/data.o: $(OBJS)/ctrl.o $(OBJS)/int_routines.o $(OBJS)/orac_constants.o \
         $(OBJS)/sad_chan.o dealloc_data.F90 determine_illum.F90 nullify_data.F90 \
-        read_alb.F90 read_cloudflags.F90 read_data.F90 read_geometry.F90 \
-        read_location.F90 read_lsflags.F90 read_msi.F90 sabotage_inputs.F90
+        read_alb.F90 read_cloudflags.F90 read_ctp.F90 read_data.F90 \
+        read_geometry.F90 read_location.F90 read_lsflags.F90 read_msi.F90 \
+        sabotage_inputs.F90
 $(OBJS)/diag.o: $(OBJS)/ctrl.o $(OBJS)/data.o $(OBJS)/orac_constants.o \
         $(OBJS)/spixel.o set_diag.F90 zero_diag.F90
 $(OBJS)/fm_routines.o: $(OBJS)/ctrl.o $(OBJS)/gzero.o $(OBJS)/int_lut_routines.o \

--- a/src/get_spixel.F90
+++ b/src/get_spixel.F90
@@ -190,6 +190,8 @@
 !    Get_Surface for Swansea model.
 ! 2015/12/17, GM: Get rid of the secant of the solar zenith angle division of
 !    surface reflectance.
+! 2022/01/27, GT: Added MSI_Data as an argument to Get_X (needed if using
+!    SelmAUX to set a priori/first guess)
 !
 ! Bugs:
 ! None known.
@@ -335,7 +337,7 @@ subroutine Get_SPixel(Ctrl, SAD_Chan, SAD_LUT, MSI_Data, RTM, SPixel, status)
       end if ! End of NSolar > 0
    end if ! End of RTMIntMeth /= RTMIntMethNone
 
-   call Get_X(Ctrl, SPixel, status)
+   call Get_X(Ctrl, SPixel, MSI_Data, status)
 !  if (status /= 0) go to 99 ! Skip further data reading
 
    ! If stat indicates a "super-pixel fatal" condition set the quality

--- a/src/get_x.F90
+++ b/src/get_x.F90
@@ -77,21 +77,25 @@
 ! 2015/08/20, GM: Fix SelmCtrl setting of SPixel%X0.
 ! 2016/01/02, AP: Ctrl%RS%diagonal_SRs produces a diagonal covariance matrix.
 ! 2016/10/21, AP: Add AppAerSw to SelmAux.
+! 2022/01/27, GT: Added Cloud top pressure SelmAux selection method of
+!    Get_State()
 !
 ! Bugs:
 ! Does not facilitate correlation between surface reflectance terms.
 !-------------------------------------------------------------------------------
 
-subroutine Get_X(Ctrl, SPixel, status)
+subroutine Get_X(Ctrl, SPixel, MSI_Data, status)
 
    use Ctrl_m
    use ORAC_Constants_m
+   use Data_m
 
    implicit none
 
    ! Declare arguments
    type(Ctrl_t),     intent(in)    :: Ctrl
    type(SPixel_t),   intent(inout) :: SPixel
+   type(Data_t),     intent(in)    :: MSI_Data
    integer,          intent(out)   :: status
 
    ! Local variables
@@ -102,13 +106,13 @@ subroutine Get_X(Ctrl, SPixel, status)
    ! Set all required state vector elements
    SPixel%Sx = 0.
    do i = 1, SPixel%Nx
-      call Set_State(SPixel%X(i), Ctrl, SPixel, status)
+      call Set_State(SPixel%X(i), Ctrl, SPixel, MSI_Data, status)
    end do
    do i = 1, SPixel%NXJ
-      call Set_State(SPixel%XJ(i), Ctrl, SPixel, status)
+      call Set_State(SPixel%XJ(i), Ctrl, SPixel, MSI_Data, status)
    end do
    do i = 1, SPixel%NXI
-      call Set_State(SPixel%XI(i), Ctrl, SPixel, status)
+      call Set_State(SPixel%XI(i), Ctrl, SPixel, MSI_Data, status)
    end do
 
 end subroutine Get_X
@@ -133,10 +137,11 @@ end subroutine Get_X
 ! Bugs:
 ! None known.
 !-------------------------------------------------------------------------------
-subroutine Set_State(i, Ctrl, SPixel, status)
+subroutine Set_State(i, Ctrl, SPixel, MSI_Data, status)
 
    use Ctrl_m
    use ORAC_Constants_m
+   use Data_m
 
    implicit none
 
@@ -144,19 +149,20 @@ subroutine Set_State(i, Ctrl, SPixel, status)
    integer,          intent(in)    :: i
    type(Ctrl_t),     intent(in)    :: Ctrl
    type(SPixel_t),   intent(inout) :: SPixel
+   type(Data_t),     intent(in)    :: MSI_Data
    integer,          intent(out)   :: status
 
 
    ! Set a priori
-   call Get_State(SPixel%AP(i), i, Ctrl, SPixel, 0, SPixel%Xb(i), &
-                  status, SPixel%Sx)
+   call Get_State(SPixel%AP(i), i, Ctrl, SPixel, MSI_Data, 0, &
+                  SPixel%Xb(i), status, SPixel%Sx)
 
    ! Set first guess
    if (SPixel%FG(i) /= SelmCtrl .and. SPixel%FG(i) == SPixel%AP(i)) then
       SPixel%X0(i) = SPixel%Xb(i)
    else
-      call Get_State(SPixel%FG(i), i, Ctrl, SPixel, 1, SPixel%X0(i), &
-                     status)
+      call Get_State(SPixel%FG(i), i, Ctrl, SPixel, MSI_Data, 1, &
+                     SPixel%X0(i), status)
    end if
 
    ! Check for internal consistency with the cloud class limits. Set the a
@@ -197,10 +203,11 @@ end subroutine Set_State
 ! Bugs:
 ! None known.
 !-------------------------------------------------------------------------------
-subroutine Get_State(mode, i, Ctrl, SPixel, flag, X, status, Err)
+subroutine Get_State(mode, i, Ctrl, SPixel, MSI_Data, flag, X, status, Err)
 
    use Ctrl_m
    use ORAC_Constants_m
+   use Data_m
 
    implicit none
 
@@ -209,6 +216,7 @@ subroutine Get_State(mode, i, Ctrl, SPixel, flag, X, status, Err)
    integer,          intent(in)    :: i
    type(Ctrl_t),     intent(in)    :: Ctrl
    type(SPixel_t),   intent(inout) :: SPixel
+   type(Data_t),     intent(in)    :: MSI_Data
    integer,          intent(in)    :: flag
    real,             intent(out)   :: X
    integer,          intent(out)   :: status
@@ -249,6 +257,18 @@ subroutine Get_State(mode, i, Ctrl, SPixel, flag, X, status, Err)
             else
                Err(i,i) = AUXErrTsSea * AUXErrTsSea * Scale2
             end if
+         end if
+
+      else if (i == IPc) then ! Cloud-top pressure
+         X = MSI_Data%State%CTP(SPixel%Loc%X0, SPixel%Loc%Y0)
+         ! Check the prior CTP value to make sure it is non-null and physically reasonable
+         if (X .gt. 10) then
+            ! Set the prior CTP error from the value in the file.
+            if (present(Err)) Err(i,i) = MSI_Data%State%CTP_var(SPixel%Loc%X0, SPixel%Loc%Y0)
+         else
+            ! If the prior CTP isn't reasonable, set status non-zero, which will cause Ctrl
+            ! value to be used (see below).
+            status = 1
          end if
 
       else if (any(i == ISP)) then

--- a/src/get_x.F90
+++ b/src/get_x.F90
@@ -262,7 +262,7 @@ subroutine Get_State(mode, i, Ctrl, SPixel, MSI_Data, flag, X, status, Err)
       else if (i == IPc) then ! Cloud-top pressure
          X = MSI_Data%State%CTP(SPixel%Loc%X0, SPixel%Loc%Y0)
          ! Check the prior CTP value to make sure it is non-null and physically reasonable
-         if (X .gt. 10) then
+         if (X .gt. MinPriorCTP) then
             ! Set the prior CTP error from the value in the file.
             if (present(Err)) Err(i,i) = MSI_Data%State%CTP_var(SPixel%Loc%X0, SPixel%Loc%Y0)
          else

--- a/src/orac_constants.F90
+++ b/src/orac_constants.F90
@@ -150,6 +150,7 @@ module ORAC_constants_m
                                                     ! up to nearest 100th
    real, parameter    :: EmsMin           = 0.0
    real, parameter    :: EmsMax           = 1.0
+   real, parameter    :: MinPriorCTP      = 10.0
 
    ! Missing data (fill) values
    real, parameter    :: MissingXn        = -999.   ! Value for "missing data" used as output when a SPixel is not processed.

--- a/src/read_ctp.F90
+++ b/src/read_ctp.F90
@@ -1,0 +1,69 @@
+!-------------------------------------------------------------------------------
+! Name: read_ctp.F90
+!
+! Purpose:
+! Controls the reading a priori cloud-top pressure values from an auxiliary data
+! file into the MSI_Data%State structure.
+!
+! Description and Algorithm details:
+! if (MSI files are not yet open)
+!    Open CTP file
+!    If open error
+!       Write error message to screen and log file
+!    else
+!      allocate MSI image segment array in Data_MSI struct.
+!
+! If (no error opening files)
+!     Read header (not used further)
+!     If read error
+!        Write error message to screen and log file
+!     Else
+!        Read byte array of size defined by Ctrl structure
+!        If read error
+!           Write error message to log file
+! Close CTP file
+!
+! Arguments:
+! Name     Type   In/Out/Both Description
+! ------------------------------------------------------------------------------
+! Ctrl     struct Both        Control structure
+! MSI_Data struct Both        Data structure: contains the cloud flag array
+!                             to be populated with data from the file. This
+!                             is overwritten as successive segments of data
+!                             are read in.
+!
+! History:
+! 2021/06/17, GT: New, based off of existing Read routines.
+! 
+! Bugs:
+! None known.
+!-------------------------------------------------------------------------------
+
+subroutine Read_CTP(Ctrl, MSI_Data)
+
+   use Ctrl_m
+   use orac_ncdf_m
+
+   implicit none
+
+   ! Argument declarations
+
+   type(Ctrl_t), intent(in)    :: Ctrl
+   type(Data_t), intent(inout) :: MSI_Data
+
+   integer :: ncid
+
+   ! Open CTP file
+   if (Ctrl%verbose) write(*,*) 'CTP file: ', trim(Ctrl%FID%CTP)
+   call ncdf_open(ncid, Ctrl%FID%CTP, 'Read_CTP_nc()')
+
+   allocate(MSI_Data%State%CTP(Ctrl%Ind%Xmax, Ctrl%Ind%Ymax))
+   allocate(MSI_Data%State%CTP_var(Ctrl%Ind%Xmax, Ctrl%Ind%Ymax))
+
+   call ncdf_read_array(ncid, "ctp", MSI_Data%State%CTP)
+   call ncdf_read_array(ncid, "ctp_var", MSI_Data%State%CTP_var)
+
+   ! Close CTP file
+   call ncdf_close(ncid, 'read_location_nc()')
+
+end subroutine Read_CTP

--- a/src/read_ctp.F90
+++ b/src/read_ctp.F90
@@ -33,7 +33,7 @@
 !                             are read in.
 !
 ! History:
-! 2021/06/17, GT: New, based off of existing Read routines.
+! 2022/01/22, GT: New, based off of existing Read routines.
 ! 
 ! Bugs:
 ! None known.

--- a/src/read_data.F90
+++ b/src/read_data.F90
@@ -75,11 +75,11 @@ subroutine Read_Data(Ctrl, MSI_Data, SAD_Chan)
    if (Ctrl%verbose) write(*,*) 'Reading LS Flag data'
    call Read_LSFlags(Ctrl, MSI_Data)
 
-   if ( ANY(Ctrl%AP(IPc,:) == SelmAux) .or. ANY(Ctrl%FG(IPc,:) == SelmAux) ) then
+   if (any(Ctrl%AP(IPc,:) == SelmAux) .or. any(Ctrl%FG(IPc,:) == SelmAux)) then
       if (Ctrl%verbose) write(*,*) 'Reading a priori CTP data'
       call Read_CTP(Ctrl, MSI_Data)
    end if
-   
+
    if (Ctrl%verbose) write(*,*) 'Reading MSI data'
    call Read_MSI(Ctrl, MSI_Data, SAD_Chan)
 

--- a/src/read_data.F90
+++ b/src/read_data.F90
@@ -31,6 +31,7 @@
 ! 2015/02/04, GM: Changes related to the new missing channel, illumination, and
 !    channel selection code.
 ! 2015/09/07, AP: Allow verbose to be controlled from the driver file.
+! 2022/01/27, GT: Added call to read a priori CTP data
 !
 ! Bugs:
 ! None known.
@@ -74,6 +75,11 @@ subroutine Read_Data(Ctrl, MSI_Data, SAD_Chan)
    if (Ctrl%verbose) write(*,*) 'Reading LS Flag data'
    call Read_LSFlags(Ctrl, MSI_Data)
 
+   if ( ANY(Ctrl%AP(IPc,:) == SelmAux) .or. ANY(Ctrl%FG(IPc,:) == SelmAux) ) then
+      if (Ctrl%verbose) write(*,*) 'Reading a priori CTP data'
+      call Read_CTP(Ctrl, MSI_Data)
+   end if
+   
    if (Ctrl%verbose) write(*,*) 'Reading MSI data'
    call Read_MSI(Ctrl, MSI_Data, SAD_Chan)
 

--- a/src/read_driver.F90
+++ b/src/read_driver.F90
@@ -147,6 +147,7 @@
 ! 2018/09/30, SRP: Delete old driver read routines.
 ! 2019/08/14, SP: Add Fengyun4A support.
 ! 2021/04/06, AP: New LUT names.
+! 2022/01/27, GT: Added CTP input file to Ctrl%FID structure.
 !
 ! Bugs:
 ! None known.
@@ -309,6 +310,7 @@ subroutine Read_Driver(Ctrl, global_atts, source_atts)
    Ctrl%FID%Geo    = trim(root_filename)//'.geo.nc'
    Ctrl%FID%Loc    = trim(root_filename)//'.loc.nc'
    Ctrl%FID%Alb    = trim(root_filename)//'.alb.nc'
+   Ctrl%FID%CTP    = trim(root_filename)//'.ctp.nc'
 
    ! Read channel related info
    call read_config_file(Ctrl, channel_ids_instr, channel_sw_flag, &
@@ -1393,9 +1395,9 @@ subroutine Read_Driver(Ctrl, global_atts, source_atts)
             end if
 
          case (SelmAux)
-            if (i /= ITs .and. .not. any(i == ISP) .and. .not. any(i == IRs)) then
+            if (i /= IPc .and. i /= ITs .and. .not. any(i == ISP) .and. .not. any(i == IRs)) then
                write(*,*) 'ERROR: Read_Driver(): AUX method ONLY supported ' // &
-                    'for setting first guess Ts, SP and Rs'
+                    'for setting first guess CTP, Ts, SP and Rs'
                stop FGMethErr
             end if
             if (any(i == ISP) .and. .not. Ctrl%RS%read_full_brdf) then
@@ -1427,9 +1429,9 @@ subroutine Read_Driver(Ctrl, global_atts, source_atts)
             end if
 
          case (SelmAux)
-            if (i /= ITs .and. .not. any(i == ISP) .and. .not. any(i == IRs)) then
+            if (i /= IPc .and. i /= ITs .and. .not. any(i == ISP) .and. .not. any(i == IRs)) then
                write(*,*) 'ERROR: Read_Driver(): AUX method ONLY supported ' // &
-                    'for setting a priori Ts, Rs, and S'
+                    'for setting a priori CTP, Ts, Rs, and S'
                stop APMethErr
             end if
             if (any(i == ISP) .and. .not. Ctrl%RS%read_full_brdf) then


### PR DESCRIPTION
These changes allow the Cloud-Top pressure first-guess and/or a priori to the set using the "AUX" method (which already exists for setting surface temperature and reflectance). To use this functionality, two things are needed:

1. A CTP NetCDF AUX file containing arrays "ctp" and "ctp_var", specifying the FG/AP values and AP _variance_ estimates respectively.
2. `Ctrl%AP(IPc,:)` and/or `Ctrl%FG(IPc,:)`  need to be set to `SelmAux` in the ORAC processor driver file.