### PR TITLE
Ignore pixel-type filter when Ctrl%NTypes_to_process == 0

### DIFF
--- a/src/get_spixel.F90
+++ b/src/get_spixel.F90
@@ -226,15 +226,17 @@ subroutine Get_SPixel(Ctrl, SAD_Chan, SAD_LUT, MSI_Data, RTM, SPixel, status)
 
    SPixel%Type = MSI_Data%Type(SPixel%Loc%X0, SPixel%Loc%Y0)
 
-   if (.not. any(Ctrl%Types_to_process(1:Ctrl%NTypes_to_process) == &
-                 SPixel%Type)) then
-      ! Incorrect particle type in SPixel. Don't process.
-      status = SPixelType
+   if (Ctrl%NTypes_to_process > 0) then
+      if (.not. any(Ctrl%Types_to_process(1:Ctrl%NTypes_to_process) == &
+                    SPixel%Type)) then
+         ! Incorrect particle type in SPixel. Don't process.
+         status = SPixelType
 #ifdef DEBUG
-      write(*, *) 'WARNING: Get_SPixel(): Incorrect particle type in  ' // &
-                  'pixel starting at:', SPixel%Loc%X0, SPixel%Loc%Y0
+         write(*, *) 'WARNING: Get_SPixel(): Incorrect particle type in  ' // &
+                     'pixel starting at:', SPixel%Loc%X0, SPixel%Loc%Y0
 #endif
-      go to 99 ! Skip further data reading
+         go to 99 ! Skip further data reading
+      end if
    end if
 
    ! Call 'Get_' subroutines. Non-zero stat flags fatal error for superpixel


### PR DESCRIPTION
When testing, ORAC will skip processing an entire scene because the `SPixel%Type` was 0 because I hadn't passed enough channels to the pre-processor. I consider this unintuitive, considering there's no output explaining why the pixel was skipped. At the very least, I'd like to be able to circumvent this bit of code.

However, I basically ignore this pixel filtering entirely so I thought I'd ask for a second opinion before making the change.