### PR TITLE
Remove include hdf.f90 statements

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -19,6 +19,7 @@ COMMON_OBJ_F90 = $(OBJS)/chunk_utils.o \
                  $(OBJS)/constants_cloud_typing_pavolonis.o \
                  $(OBJS)/global_attributes.o \
                  $(OBJS)/interpol.o \
+                 $(OBJS)/hdf.o \
                  $(OBJS)/orac_indexing.o \
                  $(OBJS)/orac_ncdf.o \
                  $(OBJS)/orac_output.o \
@@ -34,6 +35,9 @@ COMMON_OBJ   = $(COMMON_OBJ_F90) $(COMMON_OBJ_C)
 
 
 # Compilation rules
+$(OBJS)/%.o: %.f
+	$(F77) -o $@ -c $(FFLAGS) $(INC) $(AUXFLAGS) $<
+
 $(OBJS)/%.o: %.f90
 	$(F90) -o $@ -c $(FFLAGS) $(INC) $(AUXFLAGS) $<
 

--- a/common/hdf.f
+++ b/common/hdf.f
@@ -1,0 +1,7 @@
+C     Wrapper for the HDF 4 "header" file
+      module hdf_m
+          implicit none
+          public
+          include "hdf.inc"
+      contains
+      end module hdf_m

--- a/derived_products/broadband_fluxes/get_modis_aerosol.F90
+++ b/derived_products/broadband_fluxes/get_modis_aerosol.F90
@@ -20,8 +20,6 @@ subroutine get_modis_aerosol(fileIN,Nx,Ny,AREF,AOD550)
 
    implicit none
 
-   include "hdf.f90"
-
    ! Input arguments
    character(len=*), intent(in) :: fileIN  ! MODIS aerosol file
    integer(kind=lint), intent(in) :: Nx,Ny ! Satellite 1-km dimensions

--- a/derived_products/broadband_fluxes/get_modis_cloud.F90
+++ b/derived_products/broadband_fluxes/get_modis_cloud.F90
@@ -20,8 +20,6 @@ subroutine get_modis_cloud(fileIN,Nx,Ny,CTT,CTP,CTH,phase,REF,COT,cc_tot)
 
    implicit none
 
-   include "hdf.f90"
-
    ! Input arguments
    character(len=*), intent(in) :: fileIN  ! MODIS Cloud File
    integer(kind=lint), intent(in) :: Nx,Ny ! Satellite 1-km dimensions

--- a/derived_products/broadband_fluxes/read_hdf_sd_data.F90
+++ b/derived_products/broadband_fluxes/read_hdf_sd_data.F90
@@ -17,10 +17,9 @@
 subroutine read_hdf_sd_data(filename,SDS_name,elm3d,nX,nY,temp_out)
 
    use common_constants_m
+   use hdf_m, only: DFACC_READ
 
    implicit none
-
-   include "hdf.f90"
 
    ! Input arguments
    character(len=*), intent(in) :: filename

--- a/derived_products/broadband_fluxes/read_hdf_sd_dims.F90
+++ b/derived_products/broadband_fluxes/read_hdf_sd_dims.F90
@@ -17,10 +17,9 @@
 subroutine read_hdf_sd_dims(filename,SDS_name,nX,nY)
 
    use common_constants_m
+   use hdf_m, only: DFACC_READ
 
    implicit none
-
-   include "hdf.f90"
 
    ! Input arguments
    character(len=*), intent(in) :: filename

--- a/pre_processing/get_modis_time.F90
+++ b/pre_processing/get_modis_time.F90
@@ -34,8 +34,6 @@ subroutine get_modis_time(geo_id,imager_geolocation,imager_time,n_along_track)
 
    implicit none
 
-   include "hdf.f90"
-
    integer(kind=lint),         intent(in)    :: geo_id
    type(imager_geolocation_t), intent(in)    :: imager_geolocation
    type(imager_time_t),        intent(inout) :: imager_time

--- a/pre_processing/read_mcd43c1.F90
+++ b/pre_processing/read_mcd43c1.F90
@@ -35,10 +35,9 @@ subroutine read_mcd43c1(path_to_file, mcd, nbands, bands, read_params, &
                         read_QC, verbose, stat)
 
    use preproc_constants_m
+   use hdf_m, only: DFACC_READ
 
    implicit none
-
-   include "hdf.f90"
 
    ! Input variables
    character(len=*), intent(in) :: path_to_file

--- a/pre_processing/read_mcd43c3.F90
+++ b/pre_processing/read_mcd43c3.F90
@@ -43,10 +43,9 @@ subroutine read_mcd43c3(path_to_file, mcd, nbands, bands, read_ws, read_bs, &
                         read_QC, verbose, stat)
 
    use preproc_constants_m
+   use hdf_m, only: DFACC_READ
 
    implicit none
-
-   include "hdf.f90"
 
    ! Input variables
    character(len=*), intent(in) :: path_to_file

--- a/pre_processing/read_modis_angles.F90
+++ b/pre_processing/read_modis_angles.F90
@@ -38,8 +38,6 @@ subroutine read_modis_angles(fid,SDS_name,ixstart,ixstop,iystart,iystop,rtemp)
 
    implicit none
 
-   include "hdf.f90"
-
    integer,            intent(in)  :: fid
    character(len=*),   intent(in)  :: SDS_name
    integer(kind=lint), intent(in)  :: ixstart, ixstop, iystart, iystop

--- a/pre_processing/read_modis_dimensions.F90
+++ b/pre_processing/read_modis_dimensions.F90
@@ -29,10 +29,9 @@
 subroutine read_modis_dimensions(path_to_geo_file, n_across_track, n_along_track)
 
    use preproc_constants_m
+   use hdf_m, only: DFACC_READ
 
    implicit none
-
-   include "hdf.f90"
 
    character(len=*),   intent(in)  :: path_to_geo_file
    integer(kind=lint), intent(out) :: n_across_track, n_along_track

--- a/pre_processing/read_modis_l1b_radiances.F90
+++ b/pre_processing/read_modis_l1b_radiances.F90
@@ -37,10 +37,9 @@ subroutine read_modis_l1b_radiances(sensor, platform, path_to_l1b_file, &
    use channel_structures_m
    use imager_structures_m
    use preproc_constants_m
+   use hdf_m, only: DFACC_READ
 
    implicit none
-
-   include "hdf.f90"
 
    integer(kind=lint) :: l1b_id, ix, jy, ich, err_code
 

--- a/pre_processing/read_modis_l1b_radiances_2.F90
+++ b/pre_processing/read_modis_l1b_radiances_2.F90
@@ -57,8 +57,6 @@ subroutine read_modis_l1b_radiances_2(fid, band, Cal_type_is_refl, &
 
    implicit none
 
-   include "hdf.f90"
-
    integer(kind=lint), intent(in)  :: fid
    integer,            intent(in)  :: band
    logical,            intent(in)  :: Cal_type_is_refl

--- a/pre_processing/read_modis_land_sea_mask.F90
+++ b/pre_processing/read_modis_land_sea_mask.F90
@@ -35,8 +35,6 @@ subroutine read_modis_land_sea_mask(fid,SDS_name,ixstart,ixstop,iystart,iystop,b
 
    implicit none
 
-   include "hdf.f90"
-
    integer,            intent(in)  :: fid
    character(len=*),   intent(in)  :: SDS_name
    integer,            intent(in)  :: ixstart, ixstop, iystart, iystop

--- a/pre_processing/read_modis_lat_lon.F90
+++ b/pre_processing/read_modis_lat_lon.F90
@@ -36,8 +36,6 @@ subroutine read_modis_lat_lon(fid,SDS_name,startx,stopx,starty,stopy,temp)
 
    implicit none
 
-   include "hdf.f90"
-
    integer,            intent(in)  :: fid
    character(len=*),   intent(in)  :: SDS_name
    integer(kind=lint), intent(in)  :: startx, stopx, starty, stopy

--- a/pre_processing/read_modis_time.F90
+++ b/pre_processing/read_modis_time.F90
@@ -31,8 +31,6 @@ subroutine read_modis_time(fid,SDS_name,startyy,stopyy,temp)
 
    implicit none
 
-   include "hdf.f90"
-
    integer,            intent(in)  :: fid
    character(len=*),   intent(in)  :: SDS_name
    integer(kind=lint), intent(in)  :: startyy, stopyy

--- a/pre_processing/read_modis_time_lat_lon_angles.F90
+++ b/pre_processing/read_modis_time_lat_lon_angles.F90
@@ -44,10 +44,9 @@ subroutine read_modis_time_lat_lon_angles(path_to_geo_file, imager_geolocation, 
 
    use imager_structures_m
    use preproc_constants_m
+   use hdf_m, only: DFACC_READ
 
    implicit none
-
-   include "hdf.f90"
 
    character(len=*),           intent(in)    :: path_to_geo_file
    type(imager_geolocation_t), intent(inout) :: imager_geolocation

--- a/pre_processing/read_nsidc_nise.F90
+++ b/pre_processing/read_nsidc_nise.F90
@@ -172,8 +172,6 @@ function read_nsidc_nise(path_to_file, nise, north, south, verbose) &
 
    implicit none
 
-   include "hdf.f90"
-
    ! Input variables
    character(len=*), intent(in)  :: path_to_file
    integer(kind=1),  intent(in)  :: north


### PR DESCRIPTION
Recent versions of the HDF 4 library removed the hdf.f90 'header' file that we used to include parameters. The Fortran 77 version of the file, hdf.inc, remains but cannot be directly included within Fortran 90 code. I got around this by generating the desired header from the remaining one using sed but that is a non-obvious step that prevents straightforward use of an external library.

This commit creates a common module from hdf.inc and replaces the include commands with uses of that module. This should be robust against future revision of the HDF library. Would like someone to check that this works "as is".