### PR TITLE
Update SLSTR vicarious calibration adjustment coefficients.

### DIFF
--- a/pre_processing/read_slstr.F90
+++ b/pre_processing/read_slstr.F90
@@ -18,23 +18,25 @@ module read_slstr_m
 
    ! The calibration of SLSTR is under ongoing revisions, such that the
    ! application of empirical correction factors is currently required.
-   ! These are taken from the SLSTR User Guide and/or personal communications.
+   ! These are taken from personal communications and the SLSTR Vicarious
+   ! calibration adjustments document: S3MPC.RAL.TN.020, Issue 2.0, Sep 2020.
+
    real, parameter :: slstr_correction_factor(18) = [ &
-        0.95, & ! Ch1
-        -1.0, & ! Ch2
-        -1.0, & ! Ch3
+        0.97, & ! Ch1
+        0.98, & ! Ch2
+        0.98, & ! Ch3
         -1.0, & ! Ch4
-        1.10, & ! Ch5
-        1.10, & ! Ch6
+        1.11, & ! Ch5
+        1.13, & ! Ch6
         -1.0, & ! Ch7
         -1.0, & ! Ch8
         -1.0, & ! Ch9
-        0.92, & ! Ch10
-        0.93, & ! Ch11
-        0.93, & ! Ch12
+        0.94, & ! Ch10
+        0.95, & ! Ch11
+        0.95, & ! Ch12
         -1.0, & ! Ch13
-        -1.0, & ! Ch14
-        -1.0, & ! Ch15
+        1.04, & ! Ch14
+        1.07, & ! Ch15
         -1.0, & ! Ch16
         -1.0, & ! Ch17
         -1.0 ]  ! Ch18


### PR DESCRIPTION
The SLSTR reader was using out-of-date calibration coefficients for the VIS channels. This PR updates the coefs to the latest version available from the Sen-3 MPC.