### PR TITLE
Simplify Rayleigh scattering handling and fix RTTOV missing vector error

### DIFF
--- a/pre_processing/rttov_driver.F90
+++ b/pre_processing/rttov_driver.F90
@@ -443,11 +443,10 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
    ! regression limits (NB by doing this the extrapolated values outside
    ! the regression limits will be reset to the limits: it will not result
    ! in unphysical extrapolated profile values being used)
-   opts % rt_all % use_q2m                = .false. ! Do not use surface humidity
-   opts % rt_all % addrefrac              = .true.  ! Include refraction in path calc
-   opts % rt_ir % addsolar                = .true.  ! Do not include reflected solar
-   opts % rt_ir % rayleigh_max_wavelength = 0.      ! Do not run Rayleigh in RTTOV
-   opts % rt_all % ozone_data             = .true.  ! Include ozone profile
+   opts % rt_all % use_q2m         = .false. ! Do not use surface humidity
+   opts % rt_all % addrefrac       = .true.  ! Include refraction in path calc
+   opts % rt_ir % addsolar         = .true.  ! Do not include reflected solar
+   opts % rt_all % ozone_data      = .true.  ! Include ozone profile
    if (pre_opts%do_co2) then
       opts % rt_all % co2_data   = .true.  ! Include CO2 profile
    else
@@ -853,11 +852,9 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
                      ! Remove the Rayleigh component from the RTTOV tranmittances only if RTTOV
                      ! ran with Rayleigh scattering switched on.
                      if (i_coef == 2) then
-                        if (opts%rt_ir%rayleigh_max_wavelength > dither) then
-                           call remove_rayleigh(nchan, nlevels, dummy_sreal_1dveca, &
-                                profiles(count)%zenangle, profiles(count)%p, &
-                                transmission%tau_levels, transmission%tau_total)
-                         end if
+                        call remove_rayleigh(nchan, nlevels, dummy_sreal_1dveca, &
+                             profiles(count)%zenangle, profiles(count)%p, &
+                             transmission%tau_levels, transmission%tau_total)
                      end if
 
                   end if

--- a/pre_processing/rttov_driver.F90
+++ b/pre_processing/rttov_driver.F90
@@ -836,11 +836,13 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
 #ifdef INCLUDE_RTTOV_OPENMP
                      call rttov_parallel_direct(stat, chanprof, opts, &
                           profiles(count:count), coefs, transmission, radiance, &
-                          radiance2, calcemis, emissivity, calcrefl, reflectance, traj=traj)
+                          radiance2, calcemis, emissivity, calcrefl, reflectance, &
+                          traj=traj)
 #else
                      call rttov_direct(stat, chanprof, opts, &
                           profiles(count:count), coefs, transmission, radiance, &
-                          radiance2, calcemis, emissivity, calcrefl, reflectance, traj=traj)
+                          radiance2, calcemis, emissivity, calcrefl, reflectance, &
+                          traj=traj)
 #endif
 
                      if (stat /= errorstatus_success) then
@@ -903,11 +905,13 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
 #ifdef INCLUDE_RTTOV_OPENMP
                      call rttov_parallel_direct(stat, chanprof, opts, &
                           profiles(count:count), coefs, transmission, radiance, &
-                          radiance2, calcemis, emissivity, calcrefl, reflectance, traj=traj)
+                          radiance2, calcemis, emissivity, calcrefl, reflectance, &
+                          traj=traj)
 #else
                      call rttov_direct(stat, chanprof, opts, &
                           profiles(count:count), coefs, transmission, radiance, &
-                          radiance2, calcemis, emissivity, calcrefl, reflectance, traj=traj)
+                          radiance2, calcemis, emissivity, calcrefl, reflectance, &
+                          traj=traj)
 #endif
 
                      ! Save into the appropriate arrays

--- a/pre_processing/rttov_driver.F90
+++ b/pre_processing/rttov_driver.F90
@@ -851,7 +851,7 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
                      ! Remove the Rayleigh component from the RTTOV tranmittances only if RTTOV
                      ! ran with Rayleigh scattering switched on.
                      if (i_coef == 2) then
-                        if (opts%rt_ir%rayleigh_max_wavelength > dither_more) then
+                        if (opts%rt_ir%rayleigh_max_wavelength > dither) then
                            call remove_rayleigh(nchan, nlevels, dummy_sreal_1dveca, &
                                 profiles(count)%zenangle, profiles(count)%p, &
                                 transmission%tau_levels, transmission%tau_total)

--- a/pre_processing/rttov_driver.F90
+++ b/pre_processing/rttov_driver.F90
@@ -446,7 +446,7 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
    opts % rt_all % use_q2m            = .false. ! Do not use surface humidity
    opts % rt_all % addrefrac          = .true.  ! Include refraction in path calc
    opts % rt_ir % addsolar            = .true.  ! Do not include reflected solar
-   opts%rt_ir%rayleigh_max_wavelength = 0. ! Do not run RTTOV Rayleigh scattering
+   opts%rt_ir%rayleigh_max_wavelength = 0.      ! Do not run RTTOV Rayleigh scattering
    opts % rt_all % ozone_data         = .true.  ! Include ozone profile
    if (pre_opts%do_co2) then
       opts % rt_all % co2_data   = .true.  ! Include CO2 profile

--- a/pre_processing/rttov_driver.F90
+++ b/pre_processing/rttov_driver.F90
@@ -443,10 +443,11 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
    ! regression limits (NB by doing this the extrapolated values outside
    ! the regression limits will be reset to the limits: it will not result
    ! in unphysical extrapolated profile values being used)
-   opts % rt_all % use_q2m         = .false. ! Do not use surface humidity
-   opts % rt_all % addrefrac       = .true.  ! Include refraction in path calc
-   opts % rt_ir % addsolar         = .true.  ! Do not include reflected solar
-   opts % rt_all % ozone_data      = .true.  ! Include ozone profile
+   opts % rt_all % use_q2m            = .false. ! Do not use surface humidity
+   opts % rt_all % addrefrac          = .true.  ! Include refraction in path calc
+   opts % rt_ir % addsolar            = .true.  ! Do not include reflected solar
+   opts%rt_ir%rayleigh_max_wavelength = 0. ! Do not run RTTOV Rayleigh scattering
+   opts % rt_all % ozone_data         = .true.  ! Include ozone profile
    if (pre_opts%do_co2) then
       opts % rt_all % co2_data   = .true.  ! Include CO2 profile
    else
@@ -852,9 +853,11 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
                      ! Remove the Rayleigh component from the RTTOV tranmittances only if RTTOV
                      ! ran with Rayleigh scattering switched on.
                      if (i_coef == 2) then
-                        call remove_rayleigh(nchan, nlevels, dummy_sreal_1dveca, &
-                             profiles(count)%zenangle, profiles(count)%p, &
-                             transmission%tau_levels, transmission%tau_total)
+                        if (opts%rt_ir%rayleigh_max_wavelength > dither) then
+                           call remove_rayleigh(nchan, nlevels, dummy_sreal_1dveca, &
+                                profiles(count)%zenangle, profiles(count)%p, &
+                                transmission%tau_levels, transmission%tau_total)
+                        end if
                      end if
 
                   end if

--- a/pre_processing/rttov_driver.F90
+++ b/pre_processing/rttov_driver.F90
@@ -146,6 +146,11 @@
 ! 2019/08/15, SP: Add check for good pixels, meaning we don't run RTTOV on
 !                 those we don't care about. This gives a big speedup to
 !                 processing instruments that cross the dateline.
+! 2022/11/22, DP: Default behaviour switches RTTOV Rayleigh scattering off
+!                 and thus ORAC does not need to call remove_rayleigh(). 
+!                 Additionally pass calcrefl(:)=.false. and 
+!                 reflectance%refl_in=0. vectors to RTTOV to overcome the RTTOV 
+!                 error with some compilers when opts%rt_ir%addsolar=.true..
 !
 ! Bugs:
 ! - BRDF not yet implemented here, so RTTOV internal calculation used.
@@ -235,6 +240,8 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
    logical(kind=jplm),      allocatable :: calcemis(:)
    type(rttov_emissivity),  allocatable :: emissivity(:)
    real(kind=jprb),         allocatable :: emis_data(:)
+   logical(kind=jplm),      allocatable :: calcrefl(:)
+   type(rttov_reflectance), allocatable :: reflectance(:)
    type(rttov_transmission)             :: transmission
    type(rttov_radiance)                 :: radiance
    type(rttov_radiance2)                :: radiance2
@@ -436,10 +443,11 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
    ! regression limits (NB by doing this the extrapolated values outside
    ! the regression limits will be reset to the limits: it will not result
    ! in unphysical extrapolated profile values being used)
-   opts % rt_all % use_q2m   = .false. ! Do not use surface humidity
-   opts % rt_all % addrefrac = .true.  ! Include refraction in path calc
-   opts % rt_ir % addsolar   = .true.  ! Do not include reflected solar
-   opts % rt_all % ozone_data = .true.  ! Include ozone profile
+   opts % rt_all % use_q2m                = .false. ! Do not use surface humidity
+   opts % rt_all % addrefrac              = .true.  ! Include refraction in path calc
+   opts % rt_ir % addsolar                = .true.  ! Do not include reflected solar
+   opts % rt_ir % rayleigh_max_wavelength = 0.      ! Do not run Rayleigh in RTTOV
+   opts % rt_all % ozone_data             = .true.  ! Include ozone profile
    if (pre_opts%do_co2) then
       opts % rt_all % co2_data   = .true.  ! Include CO2 profile
    else
@@ -736,6 +744,15 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
          allocate(emissivity(nchan))
          allocate(emis_data(nchan))
          allocate(calcemis(nchan))
+         allocate(reflectance(nchan))
+         allocate(calcrefl(nchan))
+         
+         ! These arrays are needed when running with opts%rt_ir%addsolar
+         ! as RTTOV throws and error with some compilers. Set reflectance
+         ! vector to 0. as the surface reflecatance is explicitly handled
+         ! by the foreward model.
+         reflectance(:)%refl_in = 0.
+         calcrefl(:) = .false.
 
          chanprof%prof = 1
          do j = 1, nchan
@@ -819,11 +836,11 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
 #ifdef INCLUDE_RTTOV_OPENMP
                      call rttov_parallel_direct(stat, chanprof, opts, &
                           profiles(count:count), coefs, transmission, radiance, &
-                          radiance2, calcemis, emissivity, traj=traj)
+                          radiance2, calcemis, emissivity, calcrefl, reflectance, traj=traj)
 #else
                      call rttov_direct(stat, chanprof, opts, &
                           profiles(count:count), coefs, transmission, radiance, &
-                          radiance2, calcemis, emissivity, traj=traj)
+                          radiance2, calcemis, emissivity, calcrefl, reflectance, traj=traj)
 #endif
 
                      if (stat /= errorstatus_success) then
@@ -831,11 +848,14 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
                         stop error_stop_code
                      end if
 
-                     ! Remove the Rayleigh component from the RTTOV tranmittances.
+                     ! Remove the Rayleigh component from the RTTOV tranmittances only if RTTOV
+                     ! ran with Rayleigh scattering switched on.
                      if (i_coef == 2) then
-                        call remove_rayleigh(nchan, nlevels, dummy_sreal_1dveca, &
-                             profiles(count)%zenangle, profiles(count)%p, &
-                             transmission%tau_levels, transmission%tau_total)
+                        if (opts%rt_ir%rayleigh_max_wavelength > dither_more) then
+                           call remove_rayleigh(nchan, nlevels, dummy_sreal_1dveca, &
+                                profiles(count)%zenangle, profiles(count)%p, &
+                                transmission%tau_levels, transmission%tau_total)
+                         end if
                      end if
 
                   end if
@@ -883,11 +903,11 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
 #ifdef INCLUDE_RTTOV_OPENMP
                      call rttov_parallel_direct(stat, chanprof, opts, &
                           profiles(count:count), coefs, transmission, radiance, &
-                          radiance2, calcemis, emissivity, traj=traj)
+                          radiance2, calcemis, emissivity, calcrefl, reflectance, traj=traj)
 #else
                      call rttov_direct(stat, chanprof, opts, &
                           profiles(count:count), coefs, transmission, radiance, &
-                          radiance2, calcemis, emissivity, traj=traj)
+                          radiance2, calcemis, emissivity, calcrefl, reflectance, traj=traj)
 #endif
 
                      ! Save into the appropriate arrays
@@ -917,6 +937,8 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
          deallocate(emis_data)
          deallocate(calcemis)
          deallocate(chan_pos)
+         deallocate(calcrefl)
+         deallocate(reflectance)
       end do !coef loop
    end do  !view loop
 


### PR DESCRIPTION
As discussed I implemented some changes to rttov_driver.F90:

1. Add `calcrefl` and `reflectance` arrays to ORAC and pass them to RTTOV as they are requested by RTTOV when `opts % rt_ir % addsolar = .true.`. If not passig them, the error is "calcrefl and reflectance parameters required" (rttov13/src/main/rttov_direct.F90 L318). Some compilers seem to implicitly define those arrays and there is no error thrown but with others there is. To solve this explicitly define and pass them to RTTOV. Set `reflectance` to 0. as the surface reflectance is explicitly handled by the foreward model. Set `calcrefl` to false so that we can provide our own reflectance.
2. Yet RTTOV calculates the Rayleigh scattering what is then removed in ORAC. To simplify that switch off the Rayleigh calculations in RTTOV so that they do not need to be removed. 