### PR TITLE
Use WMO platform naming, but strip hyphens out of ORAC filenames

### DIFF
--- a/pre_processing/cloud_typing_pavolonis.F90
+++ b/pre_processing/cloud_typing_pavolonis.F90
@@ -1960,77 +1960,55 @@ function plank_inv(input_platform, T)
 
    ! select appropriate row of coefficient values
    select case (input_platform)
-   case ("noaa5")
+   case ("NOAA-5")
       index = 1
-   case ("noaa6")
+   case ("NOAA-6")
       index = 2
-   case ("noaa7")
+   case ("NOAA-7")
       index = 3
-   case ("noaa8")
+   case ("NOAA-8")
       index = 4
-   case ("noaa9")
+   case ("NOAA-9")
       index = 5
-   case ("noaa10")
+   case ("NOAA-10")
       index = 6
-   case ("noaa11")
+   case ("NOAA-11")
       index = 7
-   case ("noaa12")
+   case ("NOAA-12")
       index = 8
-   case ("noaa14")
+   case ("NOAA-14")
       index = 9
-   case ("noaa15")
+   case ("NOAA-15")
       index = 10
-   case ("noaa16")
+   case ("NOAA-16")
       index = 11
-   case ("noaa17")
+   case ("NOAA-17")
       index = 12
-   case ("noaa18")
+   case ("NOAA-18")
       index = 13
-   case ("noaa19")
+   case ("NOAA-19")
       index = 14
-   case ("metop01")
+   case ("Metop-B")
       index = 15
-   case ("metopb")
-      index = 15
-   case ("metop02")
-      index = 16
-   case ("metopa")
+   case ("Metop-A")
       index = 16
    case ("TERRA")
       index = 17
    case ("AQUA")
       index = 18
-   case ("Envisat")
+   case ("Envisat", "ERS2")
       index = 19
-   case ("ERS2")
-      index = 19
-   case ("MSG1")
+   case ("MSG-1", "MSG-2", "MSG-3", "MSG-4")
       index = 20
-   case ("MSG2")
-      index = 20
-   case ("MSG3")
-      index = 20
-   case ("MSG4")
-      index = 20
-   case ("Himawari-8")
+   case ("Himawari-8", "Himawari-9")
       index = 21
-   case ("Himawari-9")
-      index = 21
-   case ("GOES-16")
+   case ("GOES-16", "GOES-17")
       index = 22
-   case ("GOES-17")
-      index = 22
-   case ("SuomiNPP")
+   case ("Suomi-NPP", "NOAA-20")
       index = 23
-   case ("NOAA20")
-      index = 23
-   case ("Sentinel3a")
+   case ("Sentinel-3a", "Sentinel-3b")
       index = 24
-   case ("Sentinel3b")
-      index = 24
-   case ("FY-4A")
-      index = 25
-   case ("FY-4B")
+   case ("FY-4A", "FY-4B")
       index = 25
    case ("default")
       index = 26
@@ -2106,41 +2084,41 @@ function get_platform_index(input_platform)
 
    ! select appropriate row of coefficient values
    select case (input_platform)
-   case ("noaa5")
+   case ("NOAA-5")
       index = 1
-   case ("noaa6")
+   case ("NOAA-6")
       index = 2
-   case ("noaa7")
+   case ("NOAA-7")
       index = 3
-   case ("noaa8")
+   case ("NOAA-8")
       index = 4
-   case ("noaa9")
+   case ("NOAA-9")
       index = 5
-   case ("noaa10")
+   case ("NOAA-10")
       index = 6
-   case ("noaa11")
+   case ("NOAA-11")
       index = 7
-   case ("noaa12")
+   case ("NOAA-12")
       index = 8
-   case ("noaa13")
+   case ("NOAA-13")
       index = 9
-   case ("noaa14")
+   case ("NOAA-14")
       index = 10
-   case ("noaa15")
+   case ("NOAA-15")
       index = 11
-   case ("noaa16")
+   case ("NOAA-16")
       index = 12
-   case ("noaa17")
+   case ("NOAA-17")
       index = 13
-   case ("noaa18")
+   case ("NOAA-18")
       index = 14
-   case ("noaa19")
+   case ("NOAA-19")
       index = 15
-   case ("noaa20")
+   case ("NOAA-20")
       index = 16
-   case ("metopa")
+   case ("Metop-B")
       index = 17
-   case ("metop02")
+   case ("Metop-A")
       index = 18
    case ("TERRA")
       index = 19
@@ -2150,17 +2128,17 @@ function get_platform_index(input_platform)
       index = 21
    case ("Envisat")
       index = 22
-   case ("MSG1")
+   case ("MSG-1")
       index = 23
-   case ("MSG2")
+   case ("MSG-2")
       index = 24
-   case ("MSG3")
+   case ("MSG-3")
       index = 25
-   case ("MSG4")
+   case ("MSG-4")
       index = 26
-   case ("Sentinel3a")
+   case ("Sentinel-3a")
       index = 27
-   case ("Sentinel3b")
+   case ("Sentinel-3b")
       index = 28
    case ("default")
       ! 15 = NOAA19, the baseline, for which slopes = 1 and intercepts = 0

--- a/pre_processing/cloud_typing_pavolonis.F90
+++ b/pre_processing/cloud_typing_pavolonis.F90
@@ -2002,9 +2002,9 @@ function plank_inv(input_platform, T)
       index = 20
    case ("Himawari-8", "Himawari-9")
       index = 21
-   case ("GOES-16", "GOES-17")
+   case ("GOES-16", "GOES-17", "GOES-18")
       index = 22
-   case ("Suomi-NPP", "NOAA-20")
+   case ("Suomi-NPP", "NOAA-20", "NOAA-21")
       index = 23
    case ("Sentinel-3a", "Sentinel-3b")
       index = 24

--- a/pre_processing/netcdf_output_create_file.F90
+++ b/pre_processing/netcdf_output_create_file.F90
@@ -1667,7 +1667,6 @@ subroutine netcdf_put_common_attributes(ncid, global_atts, source_atts, title, &
    character(len=*),          intent(in) :: chour
    character(len=*),          intent(in) :: cminute
 
-   character(len=platform_length) :: PLATFORM_UPPER_CASE
    integer                        :: position, length
    type(global_attributes_t)      :: global_atts2
    type(source_attributes_t)      :: source_atts2
@@ -1690,13 +1689,7 @@ subroutine netcdf_put_common_attributes(ncid, global_atts, source_atts, title, &
    global_atts2%Date_Created = trim(cyear)//trim(cmonth)//trim(cday)// &
         trim(chour)//trim(cminute)
 
-   PLATFORM_UPPER_CASE = platform
-   if (platform(1:4) .eq. 'noaa') PLATFORM_UPPER_CASE(1:4) = 'NOAA'
-   if (platform(1:9) .eq. 'Sentinel3') then
-      PLATFORM_UPPER_CASE(1:10) = 'Sentinel-3'
-      PLATFORM_UPPER_CASE(11:12) = platform(10:11)
-   end if
-   global_atts2%Platform = trim(PLATFORM_UPPER_CASE)
+   global_atts2%Platform = trim(platform)
    global_atts2%Sensor   = trim(sensor)
 
    global_atts2%AATSR_Processing_Version = ' '

--- a/pre_processing/neural_net_preproc.F90
+++ b/pre_processing/neural_net_preproc.F90
@@ -193,8 +193,8 @@ subroutine ann_cloud_mask(channel1, channel2, channel3a, channel3b, &
          !Use Night ANN w/o BT3.7 at daytime
          !The early morning Noaa sats have very strong glint dependencies
          !at high viewing angles which is not captured by any ANN training.
-         if ( (trim(adjustl(platform)) .eq. 'noaa6') .or. (trim(adjustl(platform)) .eq. 'noaa8') .or. &
-              (trim(adjustl(platform)) .eq. 'noaa10') .or. (trim(adjustl(platform)) .eq. 'noaa12') .or. (trim(adjustl(platform)) .eq. 'noaa15') ) illum_nn = 6
+         if ( (trim(adjustl(platform)) .eq. 'NOAA-6') .or. (trim(adjustl(platform)) .eq. 'NOAA-8') .or. &
+              (trim(adjustl(platform)) .eq. 'NOAA-10') .or. (trim(adjustl(platform)) .eq. 'NOAA-12') .or. (trim(adjustl(platform)) .eq. 'NOAA-15') ) illum_nn = 6
       end if
    elseif (solzen  .gt. 90)  then
       illum_nn = 3                                    ! use ANN with BT3.7
@@ -649,7 +649,7 @@ subroutine ann_cloud_mask(channel1, channel2, channel3a, channel3b, &
 
    if (correct_w_unc) then
       ! do this at least for noaa12
-      if (trim(adjustl(platform)) .eq. 'noaa12') then
+      if (trim(adjustl(platform)) .eq. 'NOAA-12') then
          if ( (cldflag .eq. CLOUDY) .and. (cld_uncertainty .gt. 35.) ) cldflag = CLEAR
          !            if   (cld_uncertainty .gt. 35.) cldflag = byte_fill_value
       end if

--- a/pre_processing/preparation.F90
+++ b/pre_processing/preparation.F90
@@ -109,6 +109,9 @@ subroutine preparation(paths, granule, opts, global_atts, orbit_number, &
    real                       :: startr, endr
    character(len=32)          :: startc, endc, chunkc
 
+   character(len=platform_length) :: platform
+   integer                        :: i
+
    if (verbose) then
       write(*,*) '<<<<<<<<<<<<<<< Entering preparation()'
 
@@ -168,12 +171,19 @@ subroutine preparation(paths, granule, opts, global_atts, orbit_number, &
 
    ! ESACCI-L2-CLOUD-CLD-${sensor}_${product_string}_${platform}_*${YYYY}${MM}${DD}${HH}${II}_${version2}.*.nc
 
+   ! Remove hyphens from platform name
+   platform = adjustl(granule%platform)
+   i = index(platform, '-')
+   if (i > 0) then
+      platform = platform(1:i-1) // trim(platform(i+1:))
+   end if
+
    ! put basic filename together
    file_base = trim(adjustl(global_atts%project))//'-'// &
                trim(adjustl(opts%product_name))//'-'// &
                trim(adjustl(granule%sensor))//'_'// &
                trim(adjustl(global_atts%l2_processor))//'_'// &
-               trim(adjustl(granule%platform))//'_'// &
+               trim(adjustl(platform))//'_'// &
                trim(adjustl(granule%cyear))//trim(adjustl(granule%cmonth))// &
                trim(adjustl(granule%cday))// &
                trim(adjustl(granule%chour))//trim(adjustl(granule%cminute))//'_'

--- a/pre_processing/rttov_driver.F90
+++ b/pre_processing/rttov_driver.F90
@@ -334,19 +334,19 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
          stop error_stop_code
       end if
    case('AVHRR')
-      if (index(granule%platform, 'noaa') >= 1) then
-         if(granule%platform(5:5) == '1') then
-            coef_file_vis = 'rtcoef_noaa_'//granule%platform(5:6)//'_avhrr_o3co2.dat'
-            coef_file_ir = 'rtcoef_noaa_'//granule%platform(5:6)//'_avhrr_o3co2_ironly.dat'
+      if (granule%platform(1:4) == 'NOAA') then
+         if (len_trim(granule%platform(6:)) > 1) then
+            coef_file_vis = 'rtcoef_noaa_'//granule%platform(6:7)//'_avhrr_o3co2.dat'
+            coef_file_ir = 'rtcoef_noaa_'//granule%platform(6:7)//'_avhrr_o3co2_ironly.dat'
           else
-            coef_file_vis = 'rtcoef_noaa_'//granule%platform(5:5)//'_avhrr_o3co2.dat'
-            coef_file_ir = 'rtcoef_noaa_'//granule%platform(5:5)//'_avhrr_o3co2_ironly.dat'
+            coef_file_vis = 'rtcoef_noaa_'//granule%platform(6:6)//'_avhrr_o3co2.dat'
+            coef_file_ir = 'rtcoef_noaa_'//granule%platform(6:6)//'_avhrr_o3co2_ironly.dat'
           end if
-       else if (index(granule%platform, 'metop') >= 1) then
-          if (granule%platform(6:6) == "a") then
+       else if (granule%platform(1:5) == 'Metop') then
+          if (granule%platform(7:7) == "A") then
              coef_file_vis = 'rtcoef_metop_2_avhrr_o3co2.dat'
              coef_file_ir = 'rtcoef_metop_2_avhrr_o3co2_ironly.dat'
-          else if (granule%platform(6:6) == "b") then
+          else if (granule%platform(7:7) == "B") then
              coef_file_vis = 'rtcoef_metop_1_avhrr_o3co2.dat'
              coef_file_ir = 'rtcoef_metop_1_avhrr_o3co2_ironly.dat'
           else
@@ -372,16 +372,16 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
          stop error_stop_code
       end if
    case('SEVIRI')
-      if (trim(granule%platform) == 'MSG1') then
+      if (trim(granule%platform) == 'MSG-1') then
          coef_file_vis = 'rtcoef_msg_1_seviri_o3co2.dat'
          coef_file_ir = 'rtcoef_msg_1_seviri_o3co2_ironly.dat'
-      else if (trim(granule%platform) == 'MSG2') then
+      else if (trim(granule%platform) == 'MSG-2') then
          coef_file_vis = 'rtcoef_msg_2_seviri_o3co2.dat'
          coef_file_ir = 'rtcoef_msg_2_seviri_o3co2_ironly.dat'
-      else if (trim(granule%platform) == 'MSG3') then
+      else if (trim(granule%platform) == 'MSG-3') then
          coef_file_vis = 'rtcoef_msg_3_seviri_o3co2.dat'
          coef_file_ir = 'rtcoef_msg_3_seviri_o3co2_ironly.dat'
-      else if (trim(granule%platform) == 'MSG4') then
+      else if (trim(granule%platform) == 'MSG-4') then
          coef_file_vis = 'rtcoef_msg_4_seviri_o3co2.dat'
          coef_file_ir = 'rtcoef_msg_4_seviri_o3co2_ironly.dat'
       else
@@ -390,10 +390,10 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
          stop error_stop_code
       end if
    case('SLSTR')
-      if (trim(granule%platform) == 'Sentinel3a') then
+      if (trim(granule%platform) == 'Sentinel-3a') then
          coef_file_vis = 'rtcoef_sentinel3_1_slstr_o3co2.dat'
          coef_file_ir = 'rtcoef_sentinel3_1_slstr_o3co2_ironly.dat'
-      else if (trim(granule%platform) == 'Sentinel3b') then
+      else if (trim(granule%platform) == 'Sentinel-3b') then
          coef_file_vis = 'rtcoef_sentinel3_2_slstr_o3co2.dat'
          coef_file_ir = 'rtcoef_sentinel3_2_slstr_o3co2_ironly.dat'
       else
@@ -402,10 +402,10 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
          stop error_stop_code
       end if
    case('VIIRSI')
-      if (trim(granule%platform) == 'SuomiNPP') then
+      if (trim(granule%platform) == 'Suomi-NPP') then
          coef_file_vis = 'rtcoef_jpss_0_viirs_o3co2.dat'
          coef_file_ir = 'rtcoef_jpss_0_viirs_o3co2_ironly.dat'
-      else if (trim(granule%platform) == 'NOAA20') then
+      else if (trim(granule%platform) == 'NOAA-20') then
          coef_file_vis = 'rtcoef_noaa_20_viirs_o3co2.dat'
          coef_file_ir = 'rtcoef_noaa_20_viirs_o3co2_ironly.dat'
       else
@@ -414,10 +414,10 @@ subroutine rttov_driver(coef_path, emiss_path, granule, preproc_dims, &
          stop error_stop_code
       end if
    case('VIIRSM')
-      if (trim(granule%platform) == 'SuomiNPP') then
+      if (trim(granule%platform) == 'Suomi-NPP') then
          coef_file_vis = 'rtcoef_jpss_0_viirs_o3co2.dat'
          coef_file_ir = 'rtcoef_jpss_0_viirs_o3co2_ironly.dat'
-      else if (trim(granule%platform) == 'NOAA20') then
+      else if (trim(granule%platform) == 'NOAA-20') then
          coef_file_vis = 'rtcoef_noaa_20_viirs_o3co2.dat'
          coef_file_ir = 'rtcoef_noaa_20_viirs_o3co2_ironly.dat'
       else

--- a/pre_processing/rttov_driver_gfs.F90
+++ b/pre_processing/rttov_driver_gfs.F90
@@ -237,19 +237,19 @@ subroutine rttov_driver_gfs(coef_path, emiss_path, granule, preproc_dims, &
          stop error_stop_code
       end if
    case('AVHRR')
-      if (index(granule%platform, 'noaa') >= 1) then
-         if(granule%platform(5:5) == '1') then
-            coef_file_vis = 'rtcoef_noaa_'//granule%platform(5:6)//'_avhrr_o3co2.dat'
-            coef_file_ir = 'rtcoef_noaa_'//granule%platform(5:6)//'_avhrr_o3co2_ironly.dat'
+      if (granule%platform(1:4) == 'NOAA') then
+         if (len_trim(granule%platform(6:)) > 1) then
+            coef_file_vis = 'rtcoef_noaa_'//granule%platform(6:7)//'_avhrr_o3co2.dat'
+            coef_file_ir = 'rtcoef_noaa_'//granule%platform(6:7)//'_avhrr_o3co2_ironly.dat'
           else
-            coef_file_vis = 'rtcoef_noaa_'//granule%platform(5:5)//'_avhrr_o3co2.dat'
-            coef_file_ir = 'rtcoef_noaa_'//granule%platform(5:5)//'_avhrr_o3co2_ironly.dat'
+            coef_file_vis = 'rtcoef_noaa_'//granule%platform(6:6)//'_avhrr_o3co2.dat'
+            coef_file_ir = 'rtcoef_noaa_'//granule%platform(6:6)//'_avhrr_o3co2_ironly.dat'
           end if
-       else if (index(granule%platform, 'metop') >= 1) then
-          if (granule%platform(6:6) == "a") then
+       else if (granule%platform(1:5) == 'Metop') then
+          if (granule%platform(7:7) == "A") then
              coef_file_vis = 'rtcoef_metop_2_avhrr_o3co2.dat'
              coef_file_ir = 'rtcoef_metop_2_avhrr_o3co2_ironly.dat'
-          else if (granule%platform(6:6) == "b") then
+          else if (granule%platform(7:7) == "B") then
              coef_file_vis = 'rtcoef_metop_1_avhrr_o3co2.dat'
              coef_file_ir = 'rtcoef_metop_1_avhrr_o3co2_ironly.dat'
           else
@@ -275,16 +275,16 @@ subroutine rttov_driver_gfs(coef_path, emiss_path, granule, preproc_dims, &
          stop error_stop_code
       end if
    case('SEVIRI')
-      if (trim(granule%platform) == 'MSG1') then
+      if (trim(granule%platform) == 'MSG-1') then
          coef_file_vis = 'rtcoef_msg_1_seviri_o3co2.dat'
          coef_file_ir = 'rtcoef_msg_1_seviri_o3co2_ironly.dat'
-      else if (trim(granule%platform) == 'MSG2') then
+      else if (trim(granule%platform) == 'MSG-2') then
          coef_file_vis = 'rtcoef_msg_2_seviri_o3co2.dat'
          coef_file_ir = 'rtcoef_msg_2_seviri_o3co2_ironly.dat'
-      else if (trim(granule%platform) == 'MSG3') then
+      else if (trim(granule%platform) == 'MSG-3') then
          coef_file_vis = 'rtcoef_msg_3_seviri_o3co2.dat'
          coef_file_ir = 'rtcoef_msg_3_seviri_o3co2_ironly.dat'
-      else if (trim(granule%platform) == 'MSG4') then
+      else if (trim(granule%platform) == 'MSG-4') then
          coef_file_vis = 'rtcoef_msg_4_seviri_o3co2.dat'
          coef_file_ir = 'rtcoef_msg_4_seviri_o3co2_ironly.dat'
       else
@@ -293,10 +293,10 @@ subroutine rttov_driver_gfs(coef_path, emiss_path, granule, preproc_dims, &
          stop error_stop_code
       end if
    case('SLSTR')
-      if (trim(granule%platform) == 'Sentinel3a') then
+      if (trim(granule%platform) == 'Sentinel-3a') then
          coef_file_vis = 'rtcoef_sentinel3_1_slstr_o3co2.dat'
          coef_file_ir = 'rtcoef_sentinel3_1_slstr_o3co2_ironly.dat'
-      else if (trim(granule%platform) == 'Sentinel3b') then
+      else if (trim(granule%platform) == 'Sentinel-3b') then
          coef_file_vis = 'rtcoef_sentinel3_2_slstr_o3co2.dat'
          coef_file_ir = 'rtcoef_sentinel3_2_slstr_o3co2_ironly.dat'
       else
@@ -305,10 +305,10 @@ subroutine rttov_driver_gfs(coef_path, emiss_path, granule, preproc_dims, &
          stop error_stop_code
       end if
    case('VIIRSI')
-      if (trim(granule%platform) == 'SuomiNPP') then
+      if (trim(granule%platform) == 'Suomi-NPP') then
          coef_file_vis = 'rtcoef_jpss_0_viirs_o3co2.dat'
          coef_file_ir = 'rtcoef_jpss_0_viirs_o3co2_ironly.dat'
-      else if (trim(granule%platform) == 'NOAA20') then
+      else if (trim(granule%platform) == 'NOAA-20') then
          coef_file_vis = 'rtcoef_noaa_20_viirs_o3co2.dat'
          coef_file_ir = 'rtcoef_noaa_20_viirs_o3co2_ironly.dat'
       else
@@ -317,10 +317,10 @@ subroutine rttov_driver_gfs(coef_path, emiss_path, granule, preproc_dims, &
          stop error_stop_code
       end if
    case('VIIRSM')
-      if (trim(granule%platform) == 'SuomiNPP') then
+      if (trim(granule%platform) == 'Suomi-NPP') then
          coef_file_vis = 'rtcoef_jpss_0_viirs_o3co2.dat'
          coef_file_ir = 'rtcoef_jpss_0_viirs_o3co2_ironly.dat'
-      else if (trim(granule%platform) == 'NOAA20') then
+      else if (trim(granule%platform) == 'NOAA-20') then
          coef_file_vis = 'rtcoef_noaa_20_viirs_o3co2.dat'
          coef_file_ir = 'rtcoef_noaa_20_viirs_o3co2_ironly.dat'
       else

--- a/pre_processing/setup.F90
+++ b/pre_processing/setup.F90
@@ -783,7 +783,16 @@ subroutine setup_avhrr(args, channel_ids_user, channel_info, verbose)
 
          if (k .eq. 4) then
             ! which avhrr are we processing?
-            args%platform = trim(adjustl(str2))
+            str2 = adjustl(str2)
+            if (str2(1:4) == 'noaa') then
+               args%platform = 'NOAA-' // trim(str2(5:))
+            else if (str2(1:6) == 'metopa' .or. str2(1:7) == 'metop02') then
+               args%platform = 'Metop-A'
+            else if (str2(1:6) == 'metopb' .or. str2(1:7) == 'metop01') then
+               args%platform = 'Metop-B'
+            else
+               args%platform = trim(str2)
+            end if
          end if
       end do
 
@@ -840,8 +849,16 @@ subroutine setup_avhrr(args, channel_ids_user, channel_info, verbose)
       j = index(str1, '/', back=.true.)
       str2 = str1
       str1 = str1(1:j-1)
-      str2 = str2(j+1:)
-      args%platform = trim(adjustl(str2))
+      str2 = adjustl(str2(j+1:))
+      if (str2(1:4) == 'noaa') then
+         args%platform = 'NOAA-' // trim(str2(5:))
+      else if (str2(1:6) == 'metopa' .or. str2(1:7) == 'metop02') then
+         args%platform = 'Metop-A'
+      else if (str2(1:6) == 'metopb' .or. str2(1:7) == 'metop01') then
+         args%platform = 'Metop-B'
+      else
+         args%platform = trim(str2)
+      end if
 
       ! get year, month, day, hour and minute as integers
       read(args%cyear, '(I4)') args%year
@@ -1193,10 +1210,10 @@ subroutine setup_seviri(args, channel_ids_user, channel_info, verbose)
       !
       if (index1 .ne. 0) then
          index2 = index(args%l1b_file, '-')
-         args%platform = args%l1b_file(index2-4:index2-1)
+         args%platform = 'MSG-' // args%l1b_file(index2-1:index2-1)
       else
          index2 = index(args%l1b_file, '__-')
-         args%platform = args%l1b_file(index2+3:index2+6)
+         args%platform = 'MSG-' // args%l1b_file(index2+6:index2+6)
       end if
       index2 = index2 + index(args%l1b_file(index2 + 1:), '-')
       index2 = index2 + index(args%l1b_file(index2 + 1:), '-')
@@ -1398,11 +1415,11 @@ subroutine setup_slstr(args, source_attributes, channel_ids_user, &
    index2 = 1
    index2 = index(args%l1b_file, "S3A")
    if (index2 .gt. 1) then
-      args%platform = "Sentinel3a"
+      args%platform = "Sentinel-3a"
    else
       index2 = index(args%l1b_file, "S3B")
       if (index2 .gt. 1) then
-         args%platform = "Sentinel3b"
+         args%platform = "Sentinel-3b"
       else
          write(*,*) "ERROR: Platform must be S3A or S3B"
          stop
@@ -1577,7 +1594,7 @@ subroutine setup_viirs_mband(args, channel_ids_user, channel_info, verbose)
    if (verbose) write(*,*) 'args%geo_file: ', trim(args%geo_file)
 
    ! Assume Suomi-NPP by default
-   args%platform = "SuomiNPP"
+   args%platform = "Suomi-NPP"
    ! check if l1b and geo file are of the same granule
    index1 = index(args%l1b_file, 'npp_d', .true.)
    index2 = index(args%geo_file, 'npp_d', .true.)
@@ -1589,7 +1606,7 @@ subroutine setup_viirs_mband(args, channel_ids_user, channel_info, verbose)
          write(*,*)'ERROR: setup_viirs_iband(): Unsupported platform'
          stop error_stop_code
       end if
-      args%platform = "NOAA20"
+      args%platform = "NOAA-20"
    end if
 
 
@@ -1725,7 +1742,7 @@ subroutine setup_viirs_iband(args, channel_ids_user, channel_info, verbose)
    if (verbose) write(*,*) 'args%geo_file: ', trim(args%geo_file)
 
    ! Assume Suomi-NPP by default
-   args%platform = "SuomiNPP"
+   args%platform = "Suomi-NPP"
    ! check if l1b and geo file are of the same granule
    index1 = index(args%l1b_file, 'npp_d', .true.)
    index2 = index(args%geo_file, 'npp_d', .true.)
@@ -1737,7 +1754,7 @@ subroutine setup_viirs_iband(args, channel_ids_user, channel_info, verbose)
          write(*,*)'ERROR: setup_viirs_iband(): Unsupported platform'
          stop error_stop_code
       end if
-      args%platform = "NOAA20"
+      args%platform = "NOAA-20"
    end if
 
 
@@ -2020,13 +2037,13 @@ subroutine determine_seviri_platform_from_metoffice(l1_file, platform)
    ! https://github.com/pytroll/mpop/blob/master/mpop/satin/msg_seviri_hdf.py#L30
    select case (platform_number)
    case(321)
-      platform = "MSG1"
+      platform = "MSG-1"
    case(322)
-      platform = "MSG2"
+      platform = "MSG-2"
    case(323)
-      platform = "MSG3"
+      platform = "MSG-3"
    case(324)
-      platform = "MSG4"
+      platform = "MSG-4"
    case default
       write(*,*) "ERROR: Unrecognised platform number ", platform_number
       stop error_stop_code

--- a/pre_processing/setup.F90
+++ b/pre_processing/setup.F90
@@ -790,6 +790,8 @@ subroutine setup_avhrr(args, channel_ids_user, channel_info, verbose)
                args%platform = 'Metop-A'
             else if (str2(1:6) == 'metopb' .or. str2(1:7) == 'metop01') then
                args%platform = 'Metop-B'
+            else if (str2(1:6) == 'metopc' .or. str2(1:7) == 'metop03') then
+               args%platform = 'Metop-C'
             else
                args%platform = trim(str2)
             end if
@@ -856,6 +858,8 @@ subroutine setup_avhrr(args, channel_ids_user, channel_info, verbose)
          args%platform = 'Metop-A'
       else if (str2(1:6) == 'metopb' .or. str2(1:7) == 'metop01') then
          args%platform = 'Metop-B'
+      else if (str2(1:6) == 'metobc' .or. str2(1:7) == 'metop03') then
+         args%platform = 'Metop-C'
       else
          args%platform = trim(str2)
       end if

--- a/src/read_driver.F90
+++ b/src/read_driver.F90
@@ -774,7 +774,7 @@ subroutine Read_Driver(Ctrl, global_atts, source_atts)
       Ctrl%Ind%Y_Id_legacy(I_legacy_12_x) = 6
 
       allocate(Ctrl%ReChans(2))
-      if (Ctrl%InstName(7:12) == 'NOAA17') then
+      if (Ctrl%InstName(7:12) == 'NOAA-17') then
          Ctrl%ReChans = (/ 3, 4 /)
       else
          Ctrl%ReChans = (/ 4, 3 /)
@@ -853,8 +853,7 @@ subroutine Read_Driver(Ctrl, global_atts, source_atts)
       Ctrl%r_e_chans = (/ 3, 4 /)
       allocate(Ctrl%ir_chans(2))
       Ctrl%ir_chans  = (/ 4, 5 /)
-   else if (Ctrl%InstName(1:16) == 'SLSTR-Sentinel-3' .or. &
-        Ctrl%InstName(1:15) == 'SLSTR-Sentinel3') then
+   else if (Ctrl%InstName(1:16) == 'SLSTR-Sentinel-3') then
       Ctrl%Ind%Y_Id_legacy(I_legacy_0_6x) = 2
       Ctrl%Ind%Y_Id_legacy(I_legacy_0_8x) = 3
       Ctrl%Ind%Y_Id_legacy(I_legacy_1_6x) = 5

--- a/src/read_lwrtm.F90
+++ b/src/read_lwrtm.F90
@@ -127,21 +127,7 @@ subroutine Read_LwRTM(Ctrl, RTM)
                  Ctrl%FID%LWRTM
       stop error_stop_code
    end if
-   ! for Sentinel-3 we need to remove the "-" from the platform name
-   if (platform(1:10) == 'Sentinel-3') then
-      platform = platform(1:8)//platform(10:11)
-   end if
-   if (sensor =='AATSR' .or. sensor =='ATSR2' ) then
-      instname = trim(adjustl(sensor))
-   else
-      instname = trim(adjustl(sensor))//'-'//trim(adjustl(platform))
-   end if
-   ! for metop, sensor name needs to be capitalized
-   if (platform(1:6) == 'metopa') then
-      instname = 'AVHRR-METOPA'
-   elseif (platform(1:6) == 'metopb') then
-      instname = 'AVHRR-METOPB'
-   end if
+   instname = trim(adjustl(sensor))//'-'//trim(adjustl(platform))
 
    if (trim(adjustl(instname)) /= trim(adjustl(Ctrl%InstName))) then
       write(*,*) 'ERROR: Read_LwRTM(): Instrument in LWRTM header inconsistent: ', &

--- a/src/read_swrtm.F90
+++ b/src/read_swrtm.F90
@@ -118,21 +118,7 @@ subroutine Read_SwRTM(Ctrl, RTM)
                  Ctrl%FID%SWRTM
       stop error_stop_code
    end if
-   ! for Sentinel-3 we need to remove the "-" from the platform name
-   if (platform(1:10) == 'Sentinel-3') then
-      platform = platform(1:8)//platform(10:11)
-   end if
-   if (sensor =='AATSR' .or. sensor =='ATSR2' ) then
-      instname = trim(adjustl(sensor))
-   else
-      instname = trim(adjustl(sensor))//'-'//trim(adjustl(platform))
-   end if
-   ! for metop, sensor name needs to be capitalized
-   if (platform(1:6) == 'metopa') then
-      instname = 'AVHRR-METOPA'
-   elseif (platform(1:6) == 'metopb') then
-      instname = 'AVHRR-METOPB'
-   end if
+   instname = trim(adjustl(sensor))//'-'//trim(adjustl(platform))
 
    if (trim(adjustl(instname)) /= trim(adjustl(Ctrl%InstName))) then
       write(*,*) 'ERROR: Read_SwRTM(): Instrument in SWRTM header inconsistent: ', &

--- a/src/sad_chan.F90
+++ b/src/sad_chan.F90
@@ -235,24 +235,31 @@ function create_sad_filename2(Ctrl, chan_num, SAD_Dir, LUTClass, crp_name) &
    character(InstNameLen) :: InstName
 
    InstName = Ctrl%InstName
-   ! NOAA files use (I0) formatting in their filename; LUT files use (I2).
+   ! Remove hyphen as required
    if (InstName(1:10) == 'AVHRR-NOAA') then
-      if (len_trim(InstName(11:)) == 1) then
-         InstName(12:12) = InstName(11:11)
-         InstName(11:11) = '0'
+      ! NOAA files use (I0) formatting in their filename; LUT files use (I2).
+      if (len_trim(InstName(12:)) == 1) then
+         InstName(11:) = '0' // InstName(12:12)
+      else
+         InstName(11:) = trim(InstName(12:))
       end if
-   else if (InstName(1:11) == 'AVHRR-METOP') then
-      ! For Metop, only platform name's first letter is capitalized
-      InstName(8:11) = 'etop'
-      ! Replace MetopA with Metop2 and MetopB with Metop1
-      if (InstName(12:12) == 'A') then
-         InstName(12:12) = '2'
-      else if (InstName(12:12) == 'B') then
-         InstName(12:12) = '1'
+   else if (InstName(1:11) == 'AVHRR-Metop') then
+      ! Replace MetopA with Metop2 and MetopB with Metop1; remove hyphen
+      if (InstName(13:13) == 'A') then
+         InstName(12:) = '2'
+      else if (InstName(13:13) == 'B') then
+         InstName(12:) = '1'
       else
          write(*,*) 'ERROR: SADChan(): METOP platform name not one of METOPA or METOPB'
          stop error_stop_code
       end if
+   else if (InstName(1:10) == 'SEVIRI-MSG') then
+      InstName = 'SEVIRI-MSG' // InstName(12:12)
+   else if (InstName(8:16) == 'Suomi-NPP') then
+      InstName = InstName(1:7) // 'SuomiNPP'
+   else if (InstName(1:5) == 'ATSR2' .or. InstName(1:5) == 'AATSR') then
+      ! ATSR2/AATSR skip the platform in their filenames
+      InstName = trim(InstName(1:5))
    end if
 
    if (present(chan_num)) then

--- a/tools/pyorac/definitions.py
+++ b/tools/pyorac/definitions.py
@@ -492,6 +492,8 @@ class FileName:
             return "Metop2"
         if self.platform == "Metop-B":
             return "Metop1"
+        if self.platform == "Metop-C":
+            return "Metop3"
         if self.platform.startswith("MSG") or self.platform.startswith("Suomi"):
             return self.platform.replace("-", "")
         return self.platform

--- a/tools/pyorac/definitions.py
+++ b/tools/pyorac/definitions.py
@@ -165,8 +165,7 @@ class FileName:
         )
         if mat:
             self.sensor = 'AATSR'
-            self.platform = 'Envisat'  # For preprocessor
-            self.inst = 'AATSR'  # For main processor
+            self.platform = 'Envisat'
             self.time = datetime.datetime(
                 int(mat.group('year')), int(mat.group('month')),
                 int(mat.group('day')), int(mat.group('hour')),
@@ -186,8 +185,7 @@ class FileName:
         )
         if mat:
             self.sensor = 'ATSR2'
-            self.platform = 'ERS2'  # For preprocessor
-            self.inst = 'ATSR2'  # For main processor
+            self.platform = 'ERS2'
             self.time = datetime.datetime(
                 int(mat.group('year')), int(mat.group('month')),
                 int(mat.group('day')), int(mat.group('hour')),
@@ -206,11 +204,9 @@ class FileName:
         if mat:
             self.sensor = 'MODIS'
             if mat.group('platform') == 'O':
-                self.platform = 'TERRA'  # For preprocessor
-                self.inst = 'MODIS-TERRA'  # For main processor
+                self.platform = 'TERRA'
             else:  # == 'Y'
                 self.platform = 'AQUA'
-                self.inst = 'MODIS-AQUA'
             self.time = (datetime.datetime(
                 int(mat.group('year')), 1, 1, int(mat.group('hour')),
                 int(mat.group('min')), 0, 0
@@ -229,8 +225,7 @@ class FileName:
         )
         if mat:
             self.sensor = 'AVHRR'
-            self.platform = 'noaa' + mat.group('platform')
-            self.inst = 'AVHRR-NOAA' + mat.group('platform')
+            self.platform = 'NOAA-' + mat.group('platform')
             self.time = datetime.datetime(
                 int(mat.group('year')), int(mat.group('month')),
                 int(mat.group('day')), int(mat.group('hour')),
@@ -250,8 +245,7 @@ class FileName:
         )
         if mat:
             self.sensor = 'AVHRR'
-            self.platform = 'noaa' + mat.group('platform')
-            self.inst = 'AVHRR-NOAA' + mat.group('platform')
+            self.platform = 'NOAA-' + mat.group('platform')
             # The time specification could be fixed, as the pygac file
             # names include start and end times, to 0.1 seconds
             self.time = datetime.datetime(
@@ -273,7 +267,6 @@ class FileName:
         if mat:
             self.sensor = 'AHI'
             self.platform = 'Himawari-'+str(int(mat.group('platform')))
-            self.inst = 'AHI-'+self.platform
             self.time = datetime.datetime(
                 int(mat.group('year')), int(mat.group('month')),
                 int(mat.group('day')), int(mat.group('hour')),
@@ -292,8 +285,7 @@ class FileName:
         )
         if mat:
             self.sensor = 'SEVIRI'
-            self.platform = 'MSG' + mat.group('platform')
-            self.inst = 'SEVIRI-' + self.platform
+            self.platform = 'MSG-' + mat.group('platform')
             self.time = datetime.datetime(
                 int(mat.group('year')), int(mat.group('month')),
                 int(mat.group('day')), int(mat.group('hour')),
@@ -312,8 +304,7 @@ class FileName:
         )
         if mat:
             self.sensor = 'SEVIRI'
-            self.platform = 'MSG' + mat.group('platform')
-            self.inst = 'SEVIRI-' + self.platform
+            self.platform = 'MSG-' + mat.group('platform')
             self.time = datetime.datetime(
                 int(mat.group('year')), int(mat.group('month')),
                 int(mat.group('day')), int(mat.group('hour')),
@@ -335,7 +326,6 @@ class FileName:
                 tmp = os.path.join(fdr, filename)
                 if os.path.isfile(tmp):
                     self.platform = _determine_platform_from_metoffice(tmp)
-            self.inst = 'SEVIRI-' + self.platform
             self.time = datetime.datetime(
                 int(mat.group('year')), int(mat.group('month')),
                 int(mat.group('day')), int(mat.group('hour')),
@@ -359,7 +349,6 @@ class FileName:
             self.l1b = os.path.join(filename, "geodetic_in.nc")
             self.sensor = 'SLSTR'
             self.platform = 'Sentinel-3' + mat.group('platform').lower()
-            self.inst = 'SLSTR-Sentinel-3' + mat.group('platform').lower()
             self.dur = datetime.timedelta(seconds=int(mat.group('duration')))
             self.geo = os.path.join(filename, "geodetic_in.nc")
 
@@ -401,19 +390,14 @@ class FileName:
         )
         if mat:
             self.sensor = mat.group('sensor')
-            if self.sensor == 'SLSTR':
-                # SLSTR uses its own hyphening
-                self.platform = 'Sentinel-3' + mat.group('platform')[-1].lower()
-            else:
-                self.platform = mat.group('platform')
-            if 'ATSR' in self.sensor:
-                # SAD file names don't include platform for ATSR instruments
-                self.inst = self.sensor
-            elif self.sensor == 'SLSTR':
-                # SLSTR doesn't capitalise the platform name
-                self.inst = self.sensor + '-' + self.platform
-            else:
-                self.inst = self.sensor + '-' + self.platform.upper()
+            self.platform = mat.group('platform')
+            # Put hyphen back in platform name
+            for label in ("FY", "GOES", "Himawari", "Metop", "MSG", "NOAA",
+                          "Sentinel", "Suomi"):
+                if self.platform.startswith(label):
+                    self.platform = label + "-" + self.platform[len(label)+1:]
+                    break
+
             self.time = datetime.datetime(
                 int(mat.group('year')), int(mat.group('month')),
                 int(mat.group('day')), int(mat.group('hour')),
@@ -450,8 +434,8 @@ class FileName:
         """Returns a formatted description of this orbit."""
         if revision is None:
             revision = self.revision
-        return self.time.strftime('{}_%Y-%m-%d-%H-%M_R{}_{}'.format(
-            self.inst, revision, tag
+        return self.time.strftime('{}_{}_%Y-%m-%d-%H-%M_R{}_{}'.format(
+            self.sensor, self.platform, revision, tag
         ))
 
     def root_name(self, revision=None, processor=None, project=None,
@@ -472,7 +456,7 @@ class FileName:
                              "for ORAC filenames. Please specify " + terms[-2])
 
         parts = [
-            self.sensor, processor, self.platform.replace("Sentinel-3", "Sentinel3"),
+            self.sensor, processor, self.platform.replace("-", ""),
             self.time.strftime('%Y%m%d%H%M'), "R{}".format(revision)
         ]
         if self.orbit_num:
@@ -481,17 +465,45 @@ class FileName:
         return '-'.join((project, product_name, "_".join(parts)))
 
     @property
-    def noaa(self):
+    def avhrr_type(self):
         """Returns platform number for NOAA AVHRR sensors."""
-        plat = int(self.platform[4:])
+        if self.sensor != "AVHRR":
+            return None
+
+        if self.platform.startswith("Metop"):
+            return 3
+
+        plat = int(self.platform[5:])
         if plat in (6, 8, 10):
-            return '1'
+            return 1
         elif plat in (7, 9, 11, 12, 13, 14):
-            return '2'
+            return 2
         elif plat in (15, 16, 17, 18, 19):
-            return '3'
-        else:
-            raise ValueError("Unknown AVHRR platform: " + self.platform)
+            return 3
+
+        raise ValueError("Unknown AVHRR platform: " + self.platform)
+
+    @property
+    def text_sad_platform(self):
+        """Platform name using the formatting of the text LUTs"""
+        if self.platform.startswith("NOAA"):
+            return "NOAA{:02d}".format(int(self.platform[5:]))
+        if self.platform == "Metop-A":
+            return "Metop2"
+        if self.platform == "Metop-B":
+            return "Metop1"
+        if self.platform.startswith("MSG") or self.platform.startswith("Suomi"):
+            return self.platform.replace("-", "")
+        return self.platform
+
+    @property
+    def ncdf_sad_platform(self):
+        """Platform name using the formatting of the NCDF LUTs"""
+        if self.platform.startswith("MSG"):
+            return "meteosat-{:d}".format(int(self.platform[4:]) + 7)
+        if self.platform.startswith("FY"):
+            return "fengyun-" + self.platform[3:].lower()
+        return self.platform.lower()
 
 
 def _determine_platform_from_metoffice(filename):
@@ -503,7 +515,7 @@ def _determine_platform_from_metoffice(filename):
     if 321 > platform > 324:
         raise ValueError("Unrecognised platform number {}".format(platform))
 
-    return "MSG{}".format(platform - 320)
+    return "MSG-{}".format(platform - 320)
 
 
 # -----------------------------------------------------------------------------
@@ -582,22 +594,10 @@ class ParticleType:
     def sad_filename(self, inst):
         """Return the filename of the SAD files."""
         if self.sad == 'netcdf':
-            platform_name = inst.platform.lower()
             sensor_name = inst.sensor.lower()
-            if sensor_name == 'seviri':
-                if platform_name == 'msg1':
-                    platform_name = 'meteosat-8'
-                if platform_name == 'msg2':
-                    platform_name = 'meteosat-9'
-                if platform_name == 'msg3':
-                    platform_name = 'meteosat-10'
-                if platform_name == 'msg4':
-                    platform_name = 'meteosat-11'
-            elif sensor_name == 'avhrr':
+            if sensor_name == 'avhrr':
                 sensor_name += '1'
-                if platform_name.startswith("noaa"):
-                    platform_name = "noaa-" + platform_name[4:]
-            file_name = '_'.join((platform_name,
+            file_name = '_'.join((self.ncdf_sad_platform,
                                   sensor_name,
                                   self.mb,
                                   self.name,
@@ -605,7 +605,12 @@ class ParticleType:
                                   'p' + self.microphysical_model,
                                   'v' + self.version + '.nc'))
         else:
-            file_name = "_".join((inst.inst, self.name, "RD", "Ch*.sad"))
+            if inst.sensor in ('ATSR2', 'AATSR'):
+                instrument = inst.sensor
+            else:
+                instrument = inst.sensor + "-" + inst.text_sad_platform
+            file_name = "_".join((instrument, self.name, "RD", "Ch*.sad"))
+
         return file_name
 
     def sad_dir(self, sad_dirs, inst, rayleigh=True):
@@ -617,16 +622,15 @@ class ParticleType:
         file_name = self.sad_filename(inst)
 
         for fdr in sad_dirs:
-            if "AVHRR" in inst.sensor:
-                fdr_name = join(fdr, inst.sensor.lower() + "-" +
-                                inst.noaa + "_" + self.sad)
+            # Folder structure on JASMIN
+            if inst.sensor == "AVHRR":
+                fdr_name = join(fdr, f"avhrr-{inst.avhrr_type:d}_{self.sad}")
             else:
-                # Folder structure on JASMIN
                 fdr_name = join(fdr, inst.sensor.lower() + "_" + self.sad)
 
-                # Folder structure on local
-                # fdr_name = join(fdr, inst.sensor.lower(),
-                #                 inst.platform.upper(), self.sad)
+            # Folder structure on local
+            # fdr_name = join(fdr, inst.sensor.lower(),
+            #                 inst.text_sad_platform.upper(), self.sad)
             if not rayleigh:
                 fdr_name += "_no_ray"
 

--- a/tools/pyorac/definitions.py
+++ b/tools/pyorac/definitions.py
@@ -394,7 +394,7 @@ class FileName:
             for label in ("FY", "GOES", "Himawari", "Metop", "MSG", "NOAA",
                           "Sentinel", "Suomi"):
                 if self.platform.startswith(label):
-                    self.platform = label + "-" + self.platform[len(label)+1:]
+                    self.platform = label + "-" + self.platform[len(label):]
                     break
 
             self.time = datetime.datetime(
@@ -598,7 +598,7 @@ class ParticleType:
             sensor_name = inst.sensor.lower()
             if sensor_name == 'avhrr':
                 sensor_name += '1'
-            file_name = '_'.join((self.ncdf_sad_platform,
+            file_name = '_'.join((inst.ncdf_sad_platform,
                                   sensor_name,
                                   self.mb,
                                   self.name,

--- a/tools/pyorac/drivers.py
+++ b/tools/pyorac/drivers.py
@@ -352,7 +352,7 @@ Ctrl%RS%Use_Full_BRDF       = {use_brdf}""".format(
         out_dir=args.out_dir,
         phase=SETTINGS[args.phase].name,
         sad_dir=SETTINGS[args.phase].sad_dir(args.sad_dirs, args.File),
-        sensor=args.File.inst,
+        sensor=args.File.sensor + '-' + args.File.platform,
         use_brdf=not (args.lambertian or args.approach == 'AppAerSw'),
         verbose=args.verbose,
     )


### PR DESCRIPTION
_**This will break local scripts as it changes output file names and some driver file arguments. WE ALL NEED TO TEST THIS ONE!**_

This attempts to clean up instrument naming in ORAC. In theory, the pre and main processors will now use the same formatting for sensor/platform names while platform names will follow the WMO standard whereby there's usually a hyphen before any number. Clauses dealing with this are removed from netcdf_output_create_file.F90, read_lwrtm.F90, read_swrtm.F90 and are instead in setup.F90 when parsing input files or in sad_chan.F90 when determining the name of the text LUTs. Names for NCDF LUTs are worked out within the Python script and mostly follows the WMO standard.

An addition is made to preparation.F90 to remove hyphens from ORAC filenames as these are a protected character in CCI filenames. These are put back in by pyorac.FileName.

Theoretically, the main processor no longer requires the Ctrl%InstName
argument as it could be read from the configuration file.