### PR TITLE
Added the option to write the measurement errors to the secondary output file

### DIFF
--- a/common/alloc_output_data.F90
+++ b/common/alloc_output_data.F90
@@ -40,6 +40,7 @@
 ! 2017/05/17, OS: Added ann phase variables.
 ! 2017/07/05, AP: Add channels_used, variables_retrieved. New QC.
 ! 2018/06/08, SP: Add satellite azimuth angle to output.
+! 2023/10/10, GT: Added optional measurement uncertainties to secondary output
 !
 ! Bugs:
 ! None known.
@@ -617,6 +618,28 @@ subroutine alloc_output_data_secondary(ind, data)
    allocate(data%channels(ind%X0:ind%X1, ind%Y0:ind%Y1, ind%Ny))
    data%channels = sint_fill_value
 
+   if (ind%flags%do_meas_error) then
+      allocate(data%vid_Sy(ind%Ny))
+      data%vid_Sy = 0
+      allocate(data%Sy_scale(ind%Ny))
+      data%Sy_scale = sreal_fill_value
+      allocate(data%Sy_offset(ind%Ny))
+      data%Sy_offset = sreal_fill_value
+      allocate(data%Sy_vmin(ind%Ny))
+      data%Sy_vmin = sint_fill_value
+      allocate(data%Sy_vmax(ind%Ny))
+      data%Sy_vmax = sint_fill_value
+      allocate(data%Sy(ind%X0:ind%X1, ind%Y0:ind%Y1, ind%Ny))
+      data%Sy = sint_fill_value
+   else
+      nullify(data%vid_Sy)
+      nullify(data%Sy_scale)
+      nullify(data%Sy_offset)
+      nullify(data%Sy_vmin)
+      nullify(data%Sy_vmax)
+      nullify(data%Sy)
+   end if
+
    allocate(data%vid_y0(ind%Ny))
    data%vid_y0 = 0
    allocate(data%y0_scale(ind%Ny))
@@ -669,6 +692,13 @@ subroutine alloc_output_data_secondary(ind, data)
          data%channels_vmin(i) = 0
          data%channels_vmax(i) = 32000
 
+         if (ind%flags%do_meas_error) then
+            data%Sy_scale(i) = 0.001
+            data%Sy_offset(i) = 32.0
+            data%Sy_vmin(i) = -32000
+            data%Sy_vmax(i) = 32000
+         end if
+
          data%y0_scale(i) = 0.01
          data%y0_offset(i) = 100.0
          data%y0_vmin(i) = 0
@@ -683,6 +713,13 @@ subroutine alloc_output_data_secondary(ind, data)
          data%channels_offset(i) = 0.0
          data%channels_vmin(i) = 0
          data%channels_vmax(i) = 10000
+
+         if (ind%flags%do_meas_error) then
+            data%Sy_scale(i) = 0.00001 ! Max uncertainty of 0.32 in reflectance
+            data%Sy_offset(i) = 0.0
+            data%Sy_vmin(i) = 0
+            data%Sy_vmax(i) = 32765
+         end if
 
          data%y0_scale(i) = 0.0001
          data%y0_offset(i) = 0.0

--- a/common/def_output_secondary.F90
+++ b/common/def_output_secondary.F90
@@ -60,6 +60,7 @@
 !    to identify thermal channels rather than dealing with Ch_Is.
 ! 2016/03/04, AP: Homogenisation of I/O modules.
 ! 2016/07/08, GM: Add fields for cloud layer 2.
+! 2023/10/10, GT: Added optional output of measurement uncertainties
 !
 ! Bugs:
 ! None known.
@@ -736,6 +737,46 @@ end if
            deflate_level = deflate_level, &
            shuffle       = shuffle_flag)
    end do
+
+   !----------------------------------------------------------------------------
+   ! measurement uncertainty _in_channel_no_*
+   !----------------------------------------------------------------------------
+   if (indexing%flags%do_meas_error) then
+      do i=1,indexing%Ny
+         
+         write(input_num,"(i4)") indexing%Y_Id(i)
+         
+         if (btest(indexing%Ch_Is(i), ThermalBit)) then
+            input_dummy='measurement_uncertainty_in_channel_no_'// &
+                 trim(adjustl(input_num))
+            input_dummy2='measurement uncertainty in channel no '// &
+                 trim(adjustl(input_num))
+            input_dummy3='kelvin'
+         else
+            input_dummy='measurement_uncertainty_in_channel_no_'// &
+                 trim(adjustl(input_num))
+            input_dummy2='measurement uncertainty in channel no '// &
+                 trim(adjustl(input_num))
+            input_dummy3='1'
+         end if
+         call ncdf_def_var_short_packed_float( &
+              ncid, &
+              dims_var, &
+              trim(adjustl(input_dummy)), &
+              output_data%vid_Sy(i), &
+              verbose, &
+              long_name     = trim(adjustl(input_dummy2)), &
+              standard_name = trim(adjustl(input_dummy)), &
+              fill_value    = sint_fill_value, &
+              scale_factor  = output_data%Sy_scale(i), &
+              add_offset    = output_data%Sy_offset(i), &
+              valid_min     = output_data%Sy_vmin(i), &
+              valid_max     = output_data%Sy_vmax(i), &
+              units         = trim(adjustl(input_dummy3)), &
+              deflate_level = deflate_level, &
+              shuffle       = shuffle_flag)
+      end do
+   end if
 
    !----------------------------------------------------------------------------
    ! firstguess reflectance and brightness temperature _in_channel_no_*

--- a/common/def_output_secondary.F90
+++ b/common/def_output_secondary.F90
@@ -218,11 +218,11 @@ end if
 
 if (indexing%flags%do_rho) then
    i_rho = 0
-   do i=1,indexing%NSolar
+   do i = 1, indexing%NSolar
 
       write(input_num,"(i4)") indexing%Y_Id(indexing%YSolar(i))
 
-      do j=1,MaxRho_XX
+      do j = 1, MaxRho_XX
          if (indexing%rho_terms(i,j)) then
             i_rho = i_rho + 1
 
@@ -276,7 +276,7 @@ end if
 
 if (indexing%flags%do_swansea) then
    i_rho = 0
-   do i=1,indexing%NSolar
+   do i = 1, indexing%NSolar
       if (indexing%ss_terms(i)) then
          i_rho = i_rho + 1
 
@@ -285,9 +285,9 @@ if (indexing%flags%do_swansea) then
    !----------------------------------------------------------------------------
    ! swansea_s_ap_in_channel_no_*
    !----------------------------------------------------------------------------
-         input_dummy2='s parameter a priori in channel no '// &
+         input_dummy2 = 's parameter a priori in channel no '// &
               trim(adjustl(input_num))
-         input_dummy='swansea_s_ap_in_channel_no_'//trim(adjustl(input_num))
+         input_dummy = 'swansea_s_ap_in_channel_no_'//trim(adjustl(input_num))
 
          call ncdf_def_var_short_packed_float( &
               ncid, &
@@ -308,9 +308,9 @@ if (indexing%flags%do_swansea) then
    !----------------------------------------------------------------------------
    ! swansea_s_fg_in_channel_no_*
    !----------------------------------------------------------------------------
-         input_dummy2='s parameter first guess in channel no '// &
+         input_dummy2 = 's parameter first guess in channel no '// &
               trim(adjustl(input_num))
-         input_dummy='swansea_s_fg_in_channel_no_'//trim(adjustl(input_num))
+         input_dummy = 'swansea_s_fg_in_channel_no_'//trim(adjustl(input_num))
 
          call ncdf_def_var_short_packed_float( &
               ncid, &
@@ -331,16 +331,16 @@ if (indexing%flags%do_swansea) then
    end do
 
 
-   do i=1,indexing%NViews
+   do i = 1, indexing%NViews
 
       write(input_num,"(i4)") i
 
    !----------------------------------------------------------------------------
    ! swansea_p_ap_in_channel_no_*
    !----------------------------------------------------------------------------
-      input_dummy2='p parameter a priori in channel no '//&
+      input_dummy2 = 'p parameter a priori in channel no '//&
            trim(adjustl(input_num))
-      input_dummy='swansea_p_ap_in_view_no_'//trim(adjustl(input_num))
+      input_dummy = 'swansea_p_ap_in_view_no_'//trim(adjustl(input_num))
 
       call ncdf_def_var_short_packed_float( &
            ncid, &
@@ -361,9 +361,9 @@ if (indexing%flags%do_swansea) then
    !----------------------------------------------------------------------------
    ! swansea_p_fg_in_channel_no_*
    !----------------------------------------------------------------------------
-      input_dummy2='p parameter first guess in channel no '//&
+      input_dummy2 = 'p parameter first guess in channel no '//&
            trim(adjustl(input_num))
-      input_dummy='swansea_p_fg_in_view_no_'//trim(adjustl(input_num))
+      input_dummy = 'swansea_p_fg_in_view_no_'//trim(adjustl(input_num))
 
       call ncdf_def_var_short_packed_float( &
            ncid, &
@@ -675,12 +675,12 @@ if (indexing%flags%do_cloud) then
    !----------------------------------------------------------------------------
    ! albedo_in_channel_no_*
    !----------------------------------------------------------------------------
-   do i=1,indexing%NSolar
+   do i = 1, indexing%NSolar
 
       write(input_num,"(i4)") indexing%Y_Id(indexing%YSolar(i))
 
-      input_dummy='albedo_in_channel_no_'//trim(adjustl(input_num))
-      input_dummy2='albedo in channel no '//trim(adjustl(input_num))
+      input_dummy = 'albedo_in_channel_no_'//trim(adjustl(input_num))
+      input_dummy2 = 'albedo in channel no '//trim(adjustl(input_num))
 
       call ncdf_def_var_short_packed_float( &
            ncid, &
@@ -703,21 +703,20 @@ end if
    !----------------------------------------------------------------------------
    ! reflectance and brightness temperature _in_channel_no_*
    !----------------------------------------------------------------------------
-   do i=1,indexing%Ny
+   do i = 1, indexing%Ny
 
       write(input_num,"(i4)") indexing%Y_Id(i)
 
       if (btest(indexing%Ch_Is(i), ThermalBit)) then
-         input_dummy='brightness_temperature_in_channel_no_'// &
+         input_dummy = 'brightness_temperature_in_channel_no_'// &
               trim(adjustl(input_num))
-         input_dummy2='brightness temperature in channel no '// &
+         input_dummy2 = 'brightness temperature in channel no '// &
               trim(adjustl(input_num))
-         input_dummy3='kelvin'
+         input_dummy3 = 'kelvin'
       else
-         input_dummy='reflectance_in_channel_no_'//trim(adjustl(input_num))
-         input_dummy2='reflectance in channel no '//trim(adjustl(input_num))
-         input_dummy3='1'
-
+         input_dummy = 'reflectance_in_channel_no_'//trim(adjustl(input_num))
+         input_dummy2 = 'reflectance in channel no '//trim(adjustl(input_num))
+         input_dummy3 = '1'
       end if
 
       call ncdf_def_var_short_packed_float( &
@@ -742,22 +741,18 @@ end if
    ! measurement uncertainty _in_channel_no_*
    !----------------------------------------------------------------------------
    if (indexing%flags%do_meas_error) then
-      do i=1,indexing%Ny
-         
+      do i = 1, indexing%Ny
+
          write(input_num,"(i4)") indexing%Y_Id(i)
-         
+
+         input_dummy = 'measurement_uncertainty_in_channel_no_'// &
+              trim(adjustl(input_num))
+         input_dummy2 = 'measurement uncertainty in channel no '// &
+              trim(adjustl(input_num))
          if (btest(indexing%Ch_Is(i), ThermalBit)) then
-            input_dummy='measurement_uncertainty_in_channel_no_'// &
-                 trim(adjustl(input_num))
-            input_dummy2='measurement uncertainty in channel no '// &
-                 trim(adjustl(input_num))
-            input_dummy3='kelvin'
+            input_dummy3 = 'kelvin'
          else
-            input_dummy='measurement_uncertainty_in_channel_no_'// &
-                 trim(adjustl(input_num))
-            input_dummy2='measurement uncertainty in channel no '// &
-                 trim(adjustl(input_num))
-            input_dummy3='1'
+            input_dummy3 = '1'
          end if
          call ncdf_def_var_short_packed_float( &
               ncid, &
@@ -781,22 +776,22 @@ end if
    !----------------------------------------------------------------------------
    ! firstguess reflectance and brightness temperature _in_channel_no_*
    !----------------------------------------------------------------------------
-   do i=1,indexing%Ny
+   do i = 1, indexing%Ny
 
       write(input_num,"(i4)") indexing%Y_Id(i)
 
       if (btest(indexing%Ch_Is(i), ThermalBit)) then
-         input_dummy='firstguess_brightness_temperature_in_channel_no_'// &
+         input_dummy = 'firstguess_brightness_temperature_in_channel_no_'// &
               trim(adjustl(input_num))
-         input_dummy2='firstguess brightness temperature in channel no '// &
+         input_dummy2 = 'firstguess brightness temperature in channel no '// &
               trim(adjustl(input_num))
-         input_dummy3='kelvin'
+         input_dummy3 = 'kelvin'
       else
-         input_dummy='firstguess_reflectance_in_channel_no_'// &
+         input_dummy = 'firstguess_reflectance_in_channel_no_'// &
               trim(adjustl(input_num))
-         input_dummy2='firstguess reflectance in channel no '// &
+         input_dummy2 = 'firstguess reflectance in channel no '// &
               trim(adjustl(input_num))
-         input_dummy3='1'
+         input_dummy3 = '1'
       end if
 
       call ncdf_def_var_short_packed_float( &
@@ -820,22 +815,22 @@ end if
    !----------------------------------------------------------------------------
    ! reflectances and brightness temperature _residual_in_channel_no_*
    !----------------------------------------------------------------------------
-   do i=1,indexing%Ny
+   do i = 1, indexing%Ny
 
       write(input_num,"(i4)") indexing%Y_Id(i)
 
       if (btest(indexing%Ch_Is(i), ThermalBit)) then
-         input_dummy='brightness_temperature_residual_in_channel_no_'// &
+         input_dummy = 'brightness_temperature_residual_in_channel_no_'// &
               trim(adjustl(input_num))
-         input_dummy2='brightness temperature residual in channel no '// &
+         input_dummy2 = 'brightness temperature residual in channel no '// &
               trim(adjustl(input_num))
-         input_dummy3='kelvin'
+         input_dummy3 = 'kelvin'
       else
-         input_dummy='reflectance_residual_in_channel_no_'// &
+         input_dummy = 'reflectance_residual_in_channel_no_'// &
               trim(adjustl(input_num))
-         input_dummy2='reflectance residual in channel no '// &
+         input_dummy2 = 'reflectance residual in channel no '// &
               trim(adjustl(input_num))
-         input_dummy3='1'
+         input_dummy3 = '1'
       end if
 
       call ncdf_def_var_short_packed_float( &

--- a/common/orac_indexing.F90
+++ b/common/orac_indexing.F90
@@ -12,6 +12,7 @@
 ! 2016/07/19, AP: Reduce rho and swansea_s to only contain terms that were
 !    retrieved. This is indicated by the rho|ss_terms array (and Nrho|Nss).
 ! 2017/05/17, OS: Added ann phase variables
+! 2023/10/10, GT: Added do_meas_error flag
 !
 ! Bugs:
 ! None known.
@@ -42,6 +43,7 @@ module orac_indexing_m
 
       ! Secondary file flags
       logical :: do_covariance          ! Output the final covariance matrix
+      logical :: do_meas_error          ! Measurement uncertainties (diagonal)
    end type common_file_flags_t
 
 
@@ -97,6 +99,7 @@ module orac_indexing_m
    integer, parameter :: ann_phase_u_bit   = 10
    integer, parameter :: phase_bit         = 11
    integer, parameter :: covariance_bit    = 12
+   integer, parameter :: meas_error_bit    = 13
 
 
 contains
@@ -122,6 +125,7 @@ subroutine make_bitmask_from_common_file_flags(flags, bitmask)
    if (flags%do_ann_phase_uncertainty) bitmask = ibset(bitmask, ann_phase_u_bit)
    if (flags%do_phase)               bitmask = ibset(bitmask, phase_bit)
    if (flags%do_covariance)          bitmask = ibset(bitmask, covariance_bit)
+   if (flags%do_meas_error)          bitmask = ibset(bitmask, meas_error_bit)
 
 end subroutine make_bitmask_from_common_file_flags
 
@@ -146,6 +150,7 @@ subroutine set_common_file_flags_from_bitmask(bitmask, flags)
    flags%do_ann_phase_uncertainty = btest(bitmask, ann_phase_u_bit)
    flags%do_phase               = btest(bitmask, phase_bit)
    flags%do_covariance          = btest(bitmask, covariance_bit)
+   flags%do_meas_error          = btest(bitmask, meas_error_bit)
 
 end subroutine set_common_file_flags_from_bitmask
 

--- a/common/orac_output.F90
+++ b/common/orac_output.F90
@@ -45,6 +45,7 @@
 ! 2018/01/19, GT: Removed QCFlag scale and offset values, as these should only
 !    be used for packed floating point data (not straight integers like QCFlag).
 ! 2018/06/08, SP: Add satellite azimuth angle to output.
+! 2023/10/10, GT: Added measurement uncertainties to secondary output.
 !
 ! Bugs:
 ! None known.
@@ -600,6 +601,7 @@ module orac_output_m
       integer          :: vid_scanline_v
 
       integer, pointer :: vid_channels(:)
+      integer, pointer :: vid_Sy(:)
       integer, pointer :: vid_y0(:)
       integer, pointer :: vid_residuals(:)
 
@@ -707,6 +709,11 @@ module orac_output_m
       integer(sint), pointer :: channels_vmin(:)
       integer(sint), pointer :: channels_vmax(:)
 
+      real(sreal),   pointer :: Sy_scale(:)
+      real(sreal),   pointer :: Sy_offset(:)
+      integer(sint), pointer :: Sy_vmin(:)
+      integer(sint), pointer :: Sy_vmax(:)
+
       real(sreal),   pointer :: y0_scale(:)
       real(sreal),   pointer :: y0_offset(:)
       integer(sint), pointer :: y0_vmin(:)
@@ -759,6 +766,7 @@ module orac_output_m
       integer(sint), pointer :: albedo(:,:,:)
 
       integer(sint), pointer :: channels(:,:,:)
+      integer(sint), pointer :: Sy(:,:,:)
       integer(sint), pointer :: y0(:,:,:)
       integer(sint), pointer :: residuals(:,:,:)
 

--- a/common/write_output_secondary.F90
+++ b/common/write_output_secondary.F90
@@ -127,7 +127,7 @@ if (ind%flags%do_cloud) then
 
    do i = 1, ind%NSolar
       write(input_num,"(i4)") ind%Y_Id(i)
-      input_dummy='albedo_in_channel_no_'//trim(adjustl(input_num))
+      input_dummy = 'albedo_in_channel_no_'//trim(adjustl(input_num))
 
       call ncdf_write_array(ncid, trim(adjustl(input_dummy)), &
            output_data%vid_albedo(i), output_data%albedo(ind%X0:,:,i), &
@@ -154,7 +154,7 @@ end if
 
    do i = 1, ind%Ny
       write(input_num,"(i4)") ind%Y_Id(i)
-      input_dummy='radiance_in_channel_no_'//trim(adjustl(input_num))
+      input_dummy = 'radiance_in_channel_no_'//trim(adjustl(input_num))
 
       call ncdf_write_array(ncid, trim(adjustl(input_dummy)), &
            output_data%vid_channels(i), output_data%channels(ind%X0:,:,i), &
@@ -164,7 +164,7 @@ end if
    if (ind%flags%do_meas_error) then
       do i = 1, ind%Ny
          write(input_num,"(i4)") ind%Y_Id(i)
-         input_dummy='measurement_uncertainty_in_channel_no_'//trim(adjustl(input_num))
+         input_dummy = 'measurement_uncertainty_in_channel_no_'//trim(adjustl(input_num))
          call ncdf_write_array(ncid, trim(adjustl(input_dummy)), &
               output_data%vid_Sy(i), output_data%Sy(ind%X0:,:,i), &
               1, 1, ind%Xdim, 1, 1, ind%Ydim)
@@ -173,7 +173,7 @@ end if
 
    do i = 1, ind%Ny
       write(input_num,"(i4)") ind%Y_Id(i)
-      input_dummy='firstguess_radiance_in_channel_no_'//trim(adjustl(input_num))
+      input_dummy = 'firstguess_radiance_in_channel_no_'//trim(adjustl(input_num))
 
       call ncdf_write_array(ncid, trim(adjustl(input_dummy)), &
            output_data%vid_y0(i), output_data%y0(ind%X0:,:,i), &
@@ -182,7 +182,7 @@ end if
 
    do i = 1, ind%Ny
       write(input_num,"(i4)") ind%Y_Id(i)
-      input_dummy='radiance_residual_in_channel_no_'//trim(adjustl(input_num))
+      input_dummy = 'radiance_residual_in_channel_no_'//trim(adjustl(input_num))
 
       call ncdf_write_array(ncid, trim(adjustl(input_dummy)), &
            output_data%vid_residuals(i), output_data%residuals(ind%X0:,:,i), &
@@ -197,7 +197,7 @@ if (ind%flags%do_covariance) then
       do j = 1, ind%Nx
          write(input_num1,"(i4)") i
          write(input_num2,"(i4)") j
-         input_dummy='covariance_matrix_element_' // &
+         input_dummy = 'covariance_matrix_element_' // &
               trim(adjustl(input_num1))//trim(adjustl(input_num2))
          call ncdf_write_array(ncid, input_dummy, &
               output_data%vid_covariance(i,j), &

--- a/common/write_output_secondary.F90
+++ b/common/write_output_secondary.F90
@@ -32,6 +32,7 @@
 ! 2015/12/28, AP: Add output fields for aerosol retrievals.
 ! 2016/01/06, AP: Wrap do_* flags into output_flags structure.
 ! 2016/03/04, AP: Homogenisation of I/O modules.
+! 2023/10/10, GT: Added optional output of measurement uncertainties
 !
 ! Bugs:
 ! None known.
@@ -159,6 +160,16 @@ end if
            output_data%vid_channels(i), output_data%channels(ind%X0:,:,i), &
            1, 1, ind%Xdim, 1, 1, ind%Ydim)
    end do
+
+   if (ind%flags%do_meas_error) then
+      do i = 1, ind%Ny
+         write(input_num,"(i4)") ind%Y_Id(i)
+         input_dummy='measurement_uncertainty_in_channel_no_'//trim(adjustl(input_num))
+         call ncdf_write_array(ncid, trim(adjustl(input_dummy)), &
+              output_data%vid_Sy(i), output_data%Sy(ind%X0:,:,i), &
+              1, 1, ind%Xdim, 1, 1, ind%Ydim)
+      end do
+   end if
 
    do i = 1, ind%Ny
       write(input_num,"(i4)") ind%Y_Id(i)

--- a/post_processing/alloc_input_data.F90
+++ b/post_processing/alloc_input_data.F90
@@ -74,7 +74,7 @@ subroutine alloc_input_data_classify(ind, data, read_cost, read_ctt)
    else
       nullify(data%ctt)
    end if
-   
+
    nullify(data%aot550)
    nullify(data%aot550_uncertainty)
    nullify(data%aot870)

--- a/post_processing/alloc_input_data.F90
+++ b/post_processing/alloc_input_data.F90
@@ -41,6 +41,7 @@
 ! 2017/06/22, OS: Added phase variables.
 ! 2017/07/05, AP: Add channels_used, variables_retrieved. New QC.
 ! 2018/06/08, SP: Add satellite azimuth angle to output.
+! 2023/10/10, GT: Added measurement uncertainties to secondary data
 ! 2023/11/21, GT: Added alloc_input_data_classify() subroutine.
 ! 2024/03/07, GT: Removed unused alloc_input_data_only_cost() subroutine.
 !
@@ -620,6 +621,13 @@ subroutine alloc_input_data_secondary_common(ind, data)
       nullify(data%cer2_fg)
       nullify(data%ctp2_ap)
       nullify(data%ctp2_fg)
+   end if
+
+   if (ind%flags%do_meas_error) then
+      allocate(data%Sy(ind%X0:ind%X1, ind%Y0:ind%Y1, ind%Ny))
+      data%Sy = sreal_fill_value
+   else
+      nullify(data%Sy)
    end if
 
    allocate(data%y0(ind%X0:ind%X1, ind%Y0:ind%Y1, ind%Ny))

--- a/post_processing/dealloc_input_data.F90
+++ b/post_processing/dealloc_input_data.F90
@@ -39,6 +39,7 @@
 ! 2017/06/22, OS: Added phase variables.
 ! 2017/07/05, AP: Add channels_used, variables_retrieved. New QC.
 ! 2018/06/08, SP: Add satellite azimuth angle to output.
+! 2023/10/10, GT: Added measurement uncertainties to secondary data
 ! 2023/11/21, GT: Added dealloc_input_data_primary_classify subroutine.
 !
 ! Bugs:
@@ -245,6 +246,7 @@ subroutine dealloc_input_data_secondary_common(data)
    if (associated(data%ctp2_ap))       deallocate(data%ctp2_ap)
    if (associated(data%ctp2_fg))       deallocate(data%ctp2_fg)
 
+   if (associated(data%Sy))            deallocate(data%Sy)
    if (associated(data%y0))            deallocate(data%y0)
    if (associated(data%residuals))     deallocate(data%residuals)
    if (associated(data%ds))            deallocate(data%ds)

--- a/post_processing/dealloc_input_data.F90
+++ b/post_processing/dealloc_input_data.F90
@@ -278,4 +278,3 @@ subroutine dealloc_input_data_secondary_class(data)
    call dealloc_input_data_secondary_common(data)
 
 end subroutine dealloc_input_data_secondary_class
-

--- a/post_processing/orac_input.F90
+++ b/post_processing/orac_input.F90
@@ -35,6 +35,7 @@
 ! 2017/06/22, OS: Added phase variables.
 ! 2017/07/05, AP: Add channels_used, variables_retrieved. New QC.
 ! 2018/06/08, SP: Add satellite azimuth angle to output.
+! 2023/10/10, GT: Added measurement uncertainties to secondary data
 !
 ! Bugs:
 ! None known.
@@ -195,6 +196,7 @@ module orac_input_m
       real(sreal), pointer :: ctp2_fg(:,:)
 
       real(sreal), pointer :: channels(:,:,:)
+      real(sreal), pointer :: Sy(:,:,:)
       real(sreal), pointer :: y0(:,:,:)
       real(sreal), pointer :: residuals(:,:,:)
 
@@ -315,6 +317,7 @@ subroutine cross_reference_indexing(n, loop_ind, main_ind)
                                   any(loop_ind(1:n)%flags%do_cldmask_uncertainty)
    main_ind%flags%do_phase           = any(loop_ind(1:n)%flags%do_phase)
    main_ind%flags%do_covariance      = any(loop_ind(1:n)%flags%do_covariance)
+   main_ind%flags%do_meas_error      = any(loop_ind(1:n)%flags%do_meas_error)
    main_ind%flags%do_ann_phase  = any(loop_ind(1:n)%flags%do_ann_phase)
    main_ind%flags%do_ann_phase_uncertainty = &
                                   any(loop_ind(1:n)%flags%do_ann_phase_uncertainty)

--- a/post_processing/prepare_output_secondary_pp.F90
+++ b/post_processing/prepare_output_secondary_pp.F90
@@ -20,6 +20,7 @@
 ! 2015/12/30, AP: Have all albedo fields use the same values.
 ! 2016/03/04, AP: Tidy prepare_*_packed_float.
 ! 2017/01/09, CP: ML additions.
+! 2023/10/10, GT: Added optional output of measurement uncertainties
 !
 ! Bugs:
 ! None known.
@@ -277,6 +278,19 @@ end if
            output_data%channels_vmin(k), output_data%channels_vmax(k), &
            sreal_fill_value, sint_fill_value)
    end do
+
+   !----------------------------------------------------------------------------
+   ! Measurement error (diagonals)
+   !----------------------------------------------------------------------------
+   if (indexing%flags%do_meas_error) then
+      do k=1,indexing%Ny
+         call prepare_short_packed_float( &
+              input_data%Sy(i,j,k), output_data%Sy(i,j,k), &
+              output_data%Sy_scale(k), output_data%Sy_offset(k), &
+              output_data%Sy_vmin(k), output_data%Sy_vmax(k), &
+              sreal_fill_value, sint_fill_value)
+      end do
+   end if
 
    !----------------------------------------------------------------------------
    ! y0

--- a/post_processing/prepare_output_secondary_pp.F90
+++ b/post_processing/prepare_output_secondary_pp.F90
@@ -81,8 +81,8 @@ if (indexing%flags%do_rho) then
    ! rho_ap, rho_fg
    !----------------------------------------------------------------------------
    i_rho = 0
-   do k=1,indexing%NSolar
-      do l=1,MaxRho_XX
+   do k = 1, indexing%NSolar
+      do l = 1, MaxRho_XX
          if (indexing%rho_terms(k,l)) then
             i_rho = i_rho + 1
 
@@ -107,7 +107,7 @@ if (indexing%flags%do_swansea) then
    ! swansea_s_ap, swansea_s_fg
    !----------------------------------------------------------------------------
    i_rho = 0
-   do k=1,indexing%NSolar
+   do k = 1,indexing%NSolar
       if (indexing%ss_terms(k)) then
          i_rho = i_rho + 1
 
@@ -131,7 +131,7 @@ if (indexing%flags%do_swansea) then
       end if
    end do
 
-   do k=1,indexing%NViews
+   do k = 1, indexing%NViews
       call prepare_short_packed_float( &
            input_data%swansea_p_ap(i,j,k), output_data%swansea_p_ap(i,j,k), &
            output_data%swansea_p_ap_scale, output_data%swansea_p_ap_offset, &
@@ -210,7 +210,7 @@ if (indexing%flags%do_cloud) then
    !----------------------------------------------------------------------------
    ! albedo
    !----------------------------------------------------------------------------
-   do k=1,indexing%NSolar
+   do k = 1, indexing%NSolar
       call prepare_short_packed_float( &
            input_data%albedo(i,j,k), output_data%albedo(i,j,k), &
            output_data%albedo_scale, output_data%albedo_offset, &
@@ -271,7 +271,7 @@ end if
    !----------------------------------------------------------------------------
    ! channels
    !----------------------------------------------------------------------------
-   do k=1,indexing%Ny
+   do k = 1, indexing%Ny
       call prepare_short_packed_float( &
            input_data%channels(i,j,k), output_data%channels(i,j,k), &
            output_data%channels_scale(k), output_data%channels_offset(k), &
@@ -283,7 +283,7 @@ end if
    ! Measurement error (diagonals)
    !----------------------------------------------------------------------------
    if (indexing%flags%do_meas_error) then
-      do k=1,indexing%Ny
+      do k = 1, indexing%Ny
          call prepare_short_packed_float( &
               input_data%Sy(i,j,k), output_data%Sy(i,j,k), &
               output_data%Sy_scale(k), output_data%Sy_offset(k), &
@@ -295,7 +295,7 @@ end if
    !----------------------------------------------------------------------------
    ! y0
    !----------------------------------------------------------------------------
-   do k=1,indexing%Ny
+   do k = 1, indexing%Ny
       call prepare_short_packed_float( &
            input_data%y0(i,j,k), output_data%y0(i,j,k), &
            output_data%y0_scale(k), output_data%y0_offset(k), &
@@ -306,7 +306,7 @@ end if
    !----------------------------------------------------------------------------
    ! residuals
    !----------------------------------------------------------------------------
-   do k=1,indexing%Ny
+   do k = 1, indexing%Ny
       call prepare_short_packed_float( &
            input_data%residuals(i,j,k), output_data%residuals(i,j,k), &
            output_data%residuals_scale(k), output_data%residuals_offset(k), &

--- a/pre_processing/read_slstr_main.F90
+++ b/pre_processing/read_slstr_main.F90
@@ -96,7 +96,8 @@ end subroutine read_slstr_dimensions
 ! verbose             logical in   If true then print verbose information.
 !-------------------------------------------------------------------------------
 subroutine read_slstr(infile, imager_geolocation, imager_measurements, &
-   imager_angles, imager_time, imager_flags, channel_info, calculate_alignment, verbose)
+   imager_angles, imager_time, imager_flags, channel_info, calculate_alignment, &
+   verbose)
 
    use iso_c_binding
    use calender_m

--- a/src/get_indexing.F90
+++ b/src/get_indexing.F90
@@ -161,6 +161,8 @@ subroutine Get_Indexing(Ctrl, SAD_Chan, SPixel, MSI_Data, status)
       return
    end if
 
+   if (all(is_not_used_or_missing)) status = SPixelSkip
+
    ! Select appropriate logic for channel selection
    select case (Ctrl%Approach)
    case (AppCld1L)

--- a/src/get_spixel.F90
+++ b/src/get_spixel.F90
@@ -231,14 +231,6 @@ subroutine Get_SPixel(Ctrl, SAD_Chan, SAD_LUT, MSI_Data, RTM, SPixel, status)
 
    SPixel%Type = MSI_Data%Type(SPixel%Loc%X0, SPixel%Loc%Y0)
 
-   ! Redefine some key SPixel%Ind values here, so that _if_ the current
-   ! pixel is skipped, it is apparent that the data contained within
-   ! SPixel is not valid for the current pixel
-   SPixel%Ind%Ny = 0
-   SPixel%Ind%NSolar = 0
-   SPixel%INd%NThermal = 0 
-   SPixel%Ind%NMixed = 0
-
    if (Ctrl%NTypes_to_process > 0) then
       if (.not. any(Ctrl%Types_to_process(1:Ctrl%NTypes_to_process) == &
                     SPixel%Type)) then
@@ -354,19 +346,13 @@ subroutine Get_SPixel(Ctrl, SAD_Chan, SAD_LUT, MSI_Data, RTM, SPixel, status)
    call Get_X(Ctrl, SPixel, MSI_Data, status)
 !  if (status /= 0) go to 99 ! Skip further data reading
 
-   ! It seems that it is possible that an invalid pixel, with no
-   ! defined measurement, can reach this point without causing a
-   ! SPixel status. Check for this condition here
-   if (SPixel%Ind%Ny == 0) then
-#ifdef DEBUG
-      write(*,*) 'WARNING: Get_SPixel() No SPixel defined'
-#endif
-      status = SPixelSkip
-   end if
-
-   ! If stat indicates a "super-pixel fatal" condition set the quality
-   ! control flag bit to indicate no processing.
+   ! If stat indicates a "super-pixel fatal" condition set the channel
+   ! counts to zero to prevent output of various arrays.
 99 if (status /= 0) then
+      SPixel%Ind%Ny = 0
+      SPixel%Ind%NSolar = 0
+      SPixel%Ind%NThermal = 0
+      SPixel%Ind%NMixed = 0
 #ifdef DEBUG
      write(*,*) 'WARNING: Get_SPixel() error status', status
 #endif

--- a/src/get_spixel.F90
+++ b/src/get_spixel.F90
@@ -247,7 +247,7 @@ subroutine Get_SPixel(Ctrl, SAD_Chan, SAD_LUT, MSI_Data, RTM, SPixel, status)
 #ifdef DEBUG
          write(*, *) 'WARNING: Get_SPixel(): Incorrect particle type in  ' // &
                      'pixel starting at:', SPixel%Loc%X0, SPixel%Loc%Y0
-         write(*,*)  'Type: ',SPixelType
+         write(*,*)  'Type: ', SPixelType
 #endif
          go to 99 ! Skip further data reading
       end if

--- a/src/orac.F90
+++ b/src/orac.F90
@@ -323,6 +323,7 @@ subroutine orac(mytask,ntasks,lower_bound,upper_bound,drifile)
    Ctrl%Ind%flags%do_ann_phase_uncertainty = .true.
    Ctrl%Ind%flags%do_phase               = .false.
    Ctrl%Ind%flags%do_covariance          = .false.
+   Ctrl%Ind%flags%do_meas_error          = .true.
 
    ! Set the size of the SAD_Chan and Cloud Class arrays based on the Ctrl
    ! parameters and read the SAD values.

--- a/src/prepare_output_secondary.F90
+++ b/src/prepare_output_secondary.F90
@@ -77,8 +77,8 @@ subroutine prepare_output_secondary(Ctrl, i, j, MSI_Data, SPixel, Diag, &
    !----------------------------------------------------------------------------
    ! scanline_u, scanline_v
    !----------------------------------------------------------------------------
-   output_data%scanline_u(i,j)=i
-   output_data%scanline_v(i,j)=j
+   output_data%scanline_u(i,j) = i
+   output_data%scanline_v(i,j) = j
 
 if (Ctrl%Ind%flags%do_aerosol) then
    !----------------------------------------------------------------------------
@@ -125,10 +125,10 @@ if (Ctrl%Ind%flags%do_rho) then
    ! rho_ap, rho_fg
    !----------------------------------------------------------------------------
    i_rho = 0
-   do k=1,SPixel%Ind%NSolar
+   do k = 1, SPixel%Ind%NSolar
       kk = SPixel%spixel_y_solar_to_ctrl_y_solar_index(k)
 
-      do l=1,MaxRho_XX
+      do l = 1, MaxRho_XX
          if (Ctrl%Ind%rho_terms(kk,l)) then
             i_rho = i_rho + 1
 
@@ -153,7 +153,7 @@ if (Ctrl%Ind%flags%do_swansea) then
    ! swansea_s_ap, swansea_s_fg
    !----------------------------------------------------------------------------
    i_rho = 0
-   do k=1,SPixel%Ind%NSolar
+   do k = 1, SPixel%Ind%NSolar
       kk = SPixel%spixel_y_solar_to_ctrl_y_solar_index(k)
 
       if (Ctrl%Ind%ss_terms(kk)) then
@@ -173,7 +173,7 @@ if (Ctrl%Ind%flags%do_swansea) then
       end if
    end do
 
-   do k=1,Ctrl%Ind%NViews
+   do k = 1, Ctrl%Ind%NViews
       if (any(SPixel%X .eq. ISP(k))) then
          call prepare_short_packed_float( &
               SPixel%Xb(ISP(k)), output_data%swansea_p_ap(i,j,k), &
@@ -258,7 +258,7 @@ if (Ctrl%Ind%flags%do_cloud) then
    !----------------------------------------------------------------------------
    ! albedo
    !----------------------------------------------------------------------------
-   do k=1,Ctrl%Ind%NSolar
+   do k = 1, Ctrl%Ind%NSolar
       call prepare_short_packed_float( &
            MSI_Data%ALB(SPixel%Loc%X0,SPixel%Loc%Y0,k), &
            output_data%albedo(i,j,k), &
@@ -322,7 +322,7 @@ end if
    !----------------------------------------------------------------------------
    ! channels
    !----------------------------------------------------------------------------
-   do k=1,Ctrl%Ind%Ny
+   do k = 1, Ctrl%Ind%Ny
       call prepare_short_packed_float( &
            MSI_Data%MSI(SPixel%Loc%X0, SPixel%Loc%Y0, k), &
            output_data%channels(i,j,k), &
@@ -372,7 +372,7 @@ end if
    !----------------------------------------------------------------------------
    ! y0
    !----------------------------------------------------------------------------
-   do k=1,SPixel%Ind%Ny
+   do k = 1, SPixel%Ind%Ny
       kk = SPixel%spixel_y_to_ctrl_y_index(k)
 
       call prepare_short_packed_float( &
@@ -385,7 +385,7 @@ end if
    !----------------------------------------------------------------------------
    ! residuals
    !----------------------------------------------------------------------------
-   do k=1,SPixel%Ind%Ny
+   do k = 1, SPixel%Ind%Ny
       kk = SPixel%spixel_y_to_ctrl_y_index(k)
 
       call prepare_short_packed_float( &
@@ -405,7 +405,7 @@ end if
    else
       dummyreal = 0.0
 
-      do k=1,SPixel%Nx
+      do k = 1, SPixel%Nx
          dummyreal = dummyreal + Diag%AK(SPixel%X(k),SPixel%X(k))
       end do
    end if
@@ -419,10 +419,10 @@ end if
    ! covariance
    !----------------------------------------------------------------------------
 if (Ctrl%Ind%flags%do_covariance) then
-   do k=1,SPixel%Nx
-      do l=1,SPixel%Nx
-        call prepare_float_packed_float( &
-             real(SPixel%Sn(k,l),kind=sreal), output_data%covariance(i,j,k,l), &
+   do k = 1, SPixel%Nx
+      do l = 1, SPixel%Nx
+         call prepare_float_packed_float( &
+             real(SPixel%Sn(k,l), kind=sreal), output_data%covariance(i,j,k,l), &
              1._sreal, 0._sreal, 0._sreal, huge(dummyreal), &
              sreal_fill_value, sreal_fill_value)
       end do


### PR DESCRIPTION
It can be quite useful to see what values for measurement error are actually being used in the retrieval, so this adds the option to request the diagonals of the Sy covariance matrix be output to the seondary.nc file.