### PR TITLE
New uncertainty characterisation updates

### DIFF
--- a/common/dealloc_output_data.F90
+++ b/common/dealloc_output_data.F90
@@ -272,6 +272,15 @@ subroutine dealloc_output_data_secondary(data)
    deallocate(data%channels_vmax)
    deallocate(data%channels)
 
+   if (associated(data%Sy)) then
+      deallocate(data%Sy)
+      deallocate(data%vid_Sy)
+      deallocate(data%Sy_scale)
+      deallocate(data%Sy_offset)
+      deallocate(data%Sy_vmin)
+      deallocate(data%Sy_vmax)
+   end if
+
    deallocate(data%vid_y0)
    deallocate(data%y0_scale)
    deallocate(data%y0_offset)

--- a/common/def_output_primary.F90
+++ b/common/def_output_primary.F90
@@ -1582,8 +1582,6 @@ end if
            long_name     = 'number of retrieval iterations', &
            standard_name = '', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%niter_scale, &
-           add_offset    = output_data%niter_offset, &
            valid_min     = output_data%niter_vmin, &
            valid_max     = output_data%niter_vmax, &
            units         = '1', &
@@ -1710,8 +1708,6 @@ end if
            long_name     = 'land/sea flag', &
            standard_name = 'land_binary_mask', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%lsflag_scale, &
-           add_offset    = output_data%lsflag_offset, &
            valid_min     = output_data%lsflag_vmin, &
            valid_max     = output_data%lsflag_vmax, &
            units         = '1', &
@@ -1732,8 +1728,6 @@ end if
            long_name     = 'land use flag', &
            standard_name = 'land_use_mask', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%lusflag_scale, &
-           add_offset    = output_data%lusflag_offset, &
            valid_min     = output_data%lusflag_vmin, &
            valid_max     = output_data%lusflag_vmax, &
            units         = '1', &
@@ -1801,8 +1795,6 @@ end if
            long_name     = 'illumination flag', &
            standard_name = '', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%illum_scale, &
-           add_offset    = output_data%illum_offset, &
            valid_min     = output_data%illum_vmin, &
            valid_max     = output_data%illum_vmax, &
            units         = '1', &
@@ -1834,8 +1826,6 @@ end if
            long_name     = 'Pavolonis cloud type', &
            standard_name = '', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%cldtype_scale, &
-           add_offset    = output_data%cldtype_offset, &
            valid_min     = output_data%cldtype_vmin, &
            valid_max     = output_data%cldtype_vmax, &
            units         = '1', &
@@ -1857,8 +1847,6 @@ if (indexing%flags%do_cldmask) then
            long_name     = 'Neural net cloud mask (radiance based)', &
            standard_name = '', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%cldmask_scale, &
-           add_offset    = output_data%cldmask_offset, &
            valid_min     = output_data%cldmask_vmin, &
            valid_max     = output_data%cldmask_vmax, &
            units         = '1', &
@@ -1903,8 +1891,6 @@ if (indexing%flags%do_ann_phase) then
            long_name     = 'Neural net cloud phase mask (radiance based)', &
            standard_name = '', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%ann_phase_scale, &
-           add_offset    = output_data%ann_phase_offset, &
            valid_min     = output_data%ann_phase_vmin, &
            valid_max     = output_data%ann_phase_vmax, &
            units         = '1', &
@@ -1986,8 +1972,6 @@ if (indexing%flags%do_phase) then
            standard_name = 'thermodynamic_phase_of_cloud_water_particles_' // &
                            'at_cloud_top', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%phase_scale, &
-           add_offset    = output_data%phase_offset, &
            valid_min     = output_data%phase_vmin, &
            valid_max     = output_data%phase_vmax, &
            flag_values   = input_dummy2, &
@@ -2011,8 +1995,6 @@ if (indexing%flags%do_phase_pavolonis) then
            standard_name = 'thermodynamic_phase_of_cloud_water_particles_' // &
                            'at_cloud_top', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%phase_pavolonis_scale, &
-           add_offset    = output_data%phase_pavolonis_offset, &
            valid_min     = output_data%phase_pavolonis_vmin, &
            valid_max     = output_data%phase_pavolonis_vmax, &
            units         = '1', &
@@ -2035,8 +2017,6 @@ if (indexing%flags%do_indexing .and. present(ch_var)) then
            long_name     = 'instrument channel index', &
            standard_name = '', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%y_id_scale, &
-           add_offset    = output_data%y_id_offset, &
            valid_min     = output_data%y_id_vmin, &
            valid_max     = output_data%y_id_vmax, &
            deflate_level = deflate_level, &
@@ -2054,8 +2034,6 @@ if (indexing%flags%do_indexing .and. present(ch_var)) then
            long_name     = 'instrument channel flags', &
            standard_name = '', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%ch_is_scale, &
-           add_offset    = output_data%ch_is_offset, &
            valid_min     = output_data%ch_is_vmin, &
            valid_max     = output_data%ch_is_vmax, &
            deflate_level = deflate_level, &
@@ -2073,8 +2051,6 @@ if (indexing%flags%do_indexing .and. present(ch_var)) then
            long_name     = 'surface reflectance output flags', &
            standard_name = '', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%rho_flags_scale, &
-           add_offset    = output_data%rho_flags_offset, &
            valid_min     = output_data%rho_flags_vmin, &
            valid_max     = output_data%rho_flags_vmax, &
            deflate_level = deflate_level, &
@@ -2094,8 +2070,6 @@ if (indexing%flags%do_indexing) then
            long_name     = 'instrument channel view index', &
            standard_name = '', &
            fill_value    = byte_fill_value, &
-           scale_factor  = output_data%view_id_scale, &
-           add_offset    = output_data%view_id_offset, &
            valid_min     = output_data%view_id_vmin, &
            valid_max     = output_data%view_id_vmax, &
            deflate_level = deflate_level, &

--- a/common/def_output_secondary.F90
+++ b/common/def_output_secondary.F90
@@ -750,9 +750,17 @@ end if
          input_dummy2 = 'measurement uncertainty in channel no '// &
               trim(adjustl(input_num))
          if (btest(indexing%Ch_Is(i), ThermalBit)) then
-            input_dummy3 = 'kelvin'
+            input_dummy='measurement_uncertainty_in_channel_no_'// &
+                 trim(adjustl(input_num))
+            input_dummy2='measurement uncertainty in channel no '// &
+                 trim(adjustl(input_num))
+            input_dummy3='kelvin'
          else
-            input_dummy3 = '1'
+            input_dummy='measurement_uncertainty_in_channel_no_'// &
+                 trim(adjustl(input_num))
+            input_dummy2='measurement uncertainty in channel no '// &
+                 trim(adjustl(input_num))
+            input_dummy3='1'
          end if
          call ncdf_def_var_short_packed_float( &
               ncid, &

--- a/src/ctrl.F90
+++ b/src/ctrl.F90
@@ -285,6 +285,8 @@ module Ctrl_m
       logical                :: process_aerosol_only
       logical                :: all_channels_same_view
       logical                :: use_ann_phase
+      logical                :: use_new_meas_error ! Enable or disable new LUT
+                                                   ! uncertainty characterisation
       integer                :: NTypes_to_process  ! # of valid values in above
       integer(byte)          :: Types_to_process(MaxTypes) ! Pavolonis (or other)
                                                    ! type codes for pixels to


### PR DESCRIPTION
Added a Ctrl variable for switching between the new measurement uncertainty characterisation (if using the NetCDF LUTs) and the old approach. 
Also added deallocation of Sy output arrays, and removed unnecessary scale_factor and offset attributes from integer NetCDF variables.